### PR TITLE
How to run the README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ fn main() {
 }
 ```
 
+To run:
+
+```bash
+cd target/debug
+mpirun -np 2 ./<project_name>
+```
+
 ## Features
 
 The bindings follow the MPI 3.1 specification.


### PR DESCRIPTION
Maybe I am doing this incorrectly, but the example will not run with:

```bash
cargo build
cargo run
```

Instead I did:

```bash
cd target/debug
mpirun -np 2 ./<project_name>
```