### PR TITLE
Use c_void in std::os::raw instead of libc

### DIFF
--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -42,8 +42,7 @@
 //! `MPI_Pack_external_size()`
 
 use std::{mem};
-
-use libc::{c_void};
+use std::os::raw::{c_void};
 
 use conv::ConvUtil;
 


### PR DESCRIPTION
Only change required once #6 is fixed.

Tested with example code.