### PR TITLE
Mark use of extern static variables unsafe

### DIFF
--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1293,7 +1293,7 @@ macro_rules! system_operation_constructors {
     ($($ctor:ident => $val:path),*) => (
         $(pub fn $ctor() -> SystemOperation {
             //! A built-in operation
-            SystemOperation($val)
+            SystemOperation(unsafe_extern_static!($val))
         })*
     )
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -93,7 +93,9 @@ macro_rules! equivalent_system_datatype {
     ($rstype:path, $mpitype:path) => (
         unsafe impl Equivalence for $rstype {
             type Out = SystemDatatype;
-            fn equivalent_datatype() -> Self::Out { SystemDatatype($mpitype) }
+            fn equivalent_datatype() -> Self::Out {
+                SystemDatatype(unsafe_extern_static!($mpitype))
+            }
         }
     )
 }
@@ -311,7 +313,7 @@ impl Drop for UserDatatype {
         unsafe {
             ffi::MPI_Type_free(&mut self.0);
         }
-        assert_eq!(self.0, ffi::RSMPI_DATATYPE_NULL);
+        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_DATATYPE_NULL));
     }
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -109,10 +109,10 @@ impl Threading {
     fn as_raw(&self) -> c_int {
         use self::Threading::*;
         match *self {
-            Single => ffi::RSMPI_THREAD_SINGLE,
-            Funneled => ffi::RSMPI_THREAD_FUNNELED,
-            Serialized => ffi::RSMPI_THREAD_SERIALIZED,
-            Multiple => ffi::RSMPI_THREAD_MULTIPLE,
+            Single => unsafe_extern_static!(ffi::RSMPI_THREAD_SINGLE),
+            Funneled => unsafe_extern_static!(ffi::RSMPI_THREAD_FUNNELED),
+            Serialized => unsafe_extern_static!(ffi::RSMPI_THREAD_SERIALIZED),
+            Multiple => unsafe_extern_static!(ffi::RSMPI_THREAD_MULTIPLE),
         }
     }
 }
@@ -132,13 +132,13 @@ impl Ord for Threading {
 impl From<c_int> for Threading {
     fn from(i: c_int) -> Threading {
         use self::Threading::*;
-        if i == ffi::RSMPI_THREAD_SINGLE {
+        if i == unsafe_extern_static!(ffi::RSMPI_THREAD_SINGLE) {
             return Single;
-        } else if i == ffi::RSMPI_THREAD_FUNNELED {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_FUNNELED) {
             return Funneled;
-        } else if i == ffi::RSMPI_THREAD_SERIALIZED {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_SERIALIZED) {
             return Serialized;
-        } else if i == ffi::RSMPI_THREAD_MULTIPLE {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_MULTIPLE) {
             return Multiple;
         }
         panic!("Unknown threading level: {}", i)
@@ -234,9 +234,9 @@ pub fn version() -> (c_int, c_int) {
 ///
 /// Can be called without initializing MPI.
 pub fn library_version() -> Result<String, FromUtf8Error> {
-    let bufsize = ffi::RSMPI_MAX_LIBRARY_VERSION_STRING.value_as().expect(
+    let bufsize = unsafe_extern_static!(ffi::RSMPI_MAX_LIBRARY_VERSION_STRING).value_as().expect(
         &format!("MPI_MAX_LIBRARY_SIZE ({}) cannot be expressed as a usize.",
-            ffi::RSMPI_MAX_LIBRARY_VERSION_STRING)
+            unsafe_extern_static!(ffi::RSMPI_MAX_LIBRARY_VERSION_STRING))
         );
     let mut buf = vec![0u8; bufsize];
     let mut len: c_int = 0;
@@ -254,11 +254,11 @@ pub fn library_version() -> Result<String, FromUtf8Error> {
 ///
 /// Can return an `Err` if the processor name is not a UTF-8 string.
 pub fn processor_name() -> Result<String, FromUtf8Error> {
-    let bufsize = ffi::RSMPI_MAX_PROCESSOR_NAME.value_as()
+    let bufsize = unsafe_extern_static!(ffi::RSMPI_MAX_PROCESSOR_NAME).value_as()
                                                .expect(&format!("MPI_MAX_LIBRARY_SIZE ({}) \
                                                                  cannot be expressed as a \
                                                                  usize.",
-                                                                ffi::RSMPI_MAX_PROCESSOR_NAME));
+                                                                unsafe_extern_static!(ffi::RSMPI_MAX_PROCESSOR_NAME)));
     let mut buf = vec![0u8; bufsize];
     let mut len: c_int = 0;
 

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -86,7 +86,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.1
     fn probe(&self) -> Status {
-        self.probe_with_tag(ffi::RSMPI_ANY_TAG)
+        self.probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Probe a source for incoming messages with guaranteed reception.
@@ -125,7 +125,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.2
     fn matched_probe(&self) -> (Message, Status) {
-        self.matched_probe_with_tag(ffi::RSMPI_ANY_TAG)
+        self.matched_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Receive a message containing a single instance of type `Msg`.
@@ -165,7 +165,7 @@ pub unsafe trait Source: AsCommunicator {
     fn receive<Msg>(&self) -> (Msg, Status)
         where Msg: Equivalence
     {
-        self.receive_with_tag(ffi::RSMPI_ANY_TAG)
+        self.receive_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Receive a message into a `Buffer`.
@@ -201,7 +201,7 @@ pub unsafe trait Source: AsCommunicator {
     fn receive_into<Buf: ?Sized>(&self, buf: &mut Buf) -> Status
         where Buf: BufferMut
     {
-        self.receive_into_with_tag(buf, ffi::RSMPI_ANY_TAG)
+        self.receive_into_with_tag(buf, unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Receive a message containing multiple instances of type `Msg` into a `Vec`.
@@ -232,7 +232,7 @@ pub unsafe trait Source: AsCommunicator {
     fn receive_vec<Msg>(&self) -> (Vec<Msg>, Status)
         where Msg: Equivalence
     {
-        self.receive_vec_with_tag(ffi::RSMPI_ANY_TAG)
+        self.receive_vec_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Initiate an immediate (non-blocking) receive operation.
@@ -274,7 +274,7 @@ pub unsafe trait Source: AsCommunicator {
     fn immediate_receive_into<'b, Buf: ?Sized>(&self, buf: &'b mut Buf) -> WriteRequest<'b, Buf>
         where Buf: 'b + BufferMut
     {
-        self.immediate_receive_into_with_tag(buf, ffi::RSMPI_ANY_TAG)
+        self.immediate_receive_into_with_tag(buf, unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Initiate a non-blocking receive operation for messages matching tag `tag`.
@@ -315,7 +315,7 @@ pub unsafe trait Source: AsCommunicator {
     fn immediate_receive<Msg>(&self) -> ReceiveFuture<Msg>
         where Msg: Equivalence
     {
-        self.immediate_receive_with_tag(ffi::RSMPI_ANY_TAG)
+        self.immediate_receive_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Asynchronously probe a source for incoming messages.
@@ -354,7 +354,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.1
     fn immediate_probe(&self) -> Option<Status> {
-        self.immediate_probe_with_tag(ffi::RSMPI_ANY_TAG)
+        self.immediate_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 
     /// Asynchronously probe a source for incoming messages with guaranteed reception.
@@ -397,14 +397,14 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.2
     fn immediate_matched_probe(&self) -> Option<(Message, Status)> {
-        self.immediate_matched_probe_with_tag(ffi::RSMPI_ANY_TAG)
+        self.immediate_matched_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
     }
 }
 
 unsafe impl<'a, C> Source for AnyProcess<'a, C> where C: 'a + Communicator
 {
     fn source_rank(&self) -> Rank {
-        ffi::RSMPI_ANY_SOURCE
+        unsafe_extern_static!(ffi::RSMPI_ANY_SOURCE)
     }
 }
 
@@ -804,7 +804,7 @@ pub struct Message(MPI_Message);
 impl Message {
     /// True if the `Source` for the probe was the null process.
     pub fn is_no_proc(&self) -> bool {
-        self.as_raw() == ffi::RSMPI_MESSAGE_NO_PROC
+        self.as_raw() == unsafe_extern_static!(ffi::RSMPI_MESSAGE_NO_PROC)
     }
 
     /// Receive a previously probed message containing a single instance of type `Msg`.
@@ -882,7 +882,7 @@ unsafe impl AsRawMut for Message {
 
 impl Drop for Message {
     fn drop(&mut self) {
-        assert!(self.as_raw() == ffi::RSMPI_MESSAGE_NULL,
+        assert!(self.as_raw() == unsafe_extern_static!(ffi::RSMPI_MESSAGE_NULL),
                 "matched message dropped without receiving.");
     }
 }
@@ -956,7 +956,7 @@ pub fn send_receive<R, M, D, S>(msg: &M, destination: &D, source: &S) -> (R, Sta
           R: Equivalence,
           S: Source
 {
-    send_receive_with_tags(msg, destination, Tag::default(), source, ffi::RSMPI_ANY_TAG)
+    send_receive_with_tags(msg, destination, Tag::default(), source, unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
 }
 
 /// Sends the contents of `msg` to `destination` tagging it `sendtag` and
@@ -1020,7 +1020,7 @@ pub fn send_receive_into<M: ?Sized, D, B: ?Sized, S>(msg: &M,
                                 Tag::default(),
                                 buf,
                                 source,
-                                ffi::RSMPI_ANY_TAG)
+                                unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
 }
 
 /// Sends the contents of `buf` to `destination` tagging it `sendtag` and
@@ -1076,7 +1076,7 @@ pub fn send_receive_replace_into<B: ?Sized, D, S>(buf: &mut B,
                                         destination,
                                         Tag::default(),
                                         source,
-                                        ffi::RSMPI_ANY_TAG)
+                                        unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
 }
 
 /// Will contain a value of type `T` received via a non-blocking receive operation.

--- a/src/request.rs
+++ b/src/request.rs
@@ -37,7 +37,7 @@ pub mod traits {
 pub trait Request: AsRaw<Raw = MPI_Request> + AsRawMut {
     /// Returns true for a null request handle.
     fn is_null(&self) -> bool {
-        self.as_raw() == ffi::RSMPI_REQUEST_NULL
+        self.as_raw() == unsafe_extern_static!(ffi::RSMPI_REQUEST_NULL)
     }
 
     /// Wait for an operation to finish.

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -62,13 +62,13 @@ impl SystemCommunicator {
     /// # Examples
     /// See `examples/simple.rs`
     pub fn world() -> SystemCommunicator {
-        SystemCommunicator::from_raw_unchecked(ffi::RSMPI_COMM_WORLD)
+        SystemCommunicator::from_raw_unchecked(unsafe_extern_static!(ffi::RSMPI_COMM_WORLD))
     }
 
     /// If the raw value is the null handle returns `None`
     #[allow(dead_code)]
     fn from_raw(raw: MPI_Comm) -> Option<SystemCommunicator> {
-        if raw == ffi::RSMPI_COMM_NULL {
+        if raw == unsafe_extern_static!(ffi::RSMPI_COMM_NULL) {
             None
         } else {
             Some(SystemCommunicator(raw))
@@ -77,7 +77,7 @@ impl SystemCommunicator {
 
     /// Wraps the raw value without checking for null handle
     fn from_raw_unchecked(raw: MPI_Comm) -> SystemCommunicator {
-        debug_assert!(raw != ffi::RSMPI_COMM_NULL);
+        debug_assert!(raw != unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
         SystemCommunicator(raw)
     }
 }
@@ -108,7 +108,7 @@ pub struct UserCommunicator(MPI_Comm);
 impl UserCommunicator {
     /// If the raw value is the null handle returns `None`
     fn from_raw(raw: MPI_Comm) -> Option<UserCommunicator> {
-        if raw == ffi::RSMPI_COMM_NULL {
+        if raw == unsafe_extern_static!(ffi::RSMPI_COMM_NULL) {
             None
         } else {
             Some(UserCommunicator(raw))
@@ -117,7 +117,7 @@ impl UserCommunicator {
 
     /// Wraps the raw value without checking for null handle
     fn from_raw_unchecked(raw: MPI_Comm) -> UserCommunicator {
-        debug_assert!(raw != ffi::RSMPI_COMM_NULL);
+        debug_assert!(raw != unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
         UserCommunicator(raw)
     }
 }
@@ -143,7 +143,7 @@ impl Drop for UserCommunicator {
         unsafe {
             ffi::MPI_Comm_free(&mut self.0);
         }
-        assert_eq!(self.0, ffi::RSMPI_COMM_NULL);
+        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
     }
 }
 
@@ -154,7 +154,7 @@ pub struct Color(c_int);
 impl Color {
     /// Special color of undefined value
     pub fn undefined() -> Color {
-        Color(ffi::RSMPI_UNDEFINED)
+        Color(unsafe_extern_static!(ffi::RSMPI_UNDEFINED))
     }
 
     /// A color of a certain value
@@ -413,13 +413,13 @@ impl From<c_int> for CommunicatorRelation {
     fn from(i: c_int) -> CommunicatorRelation {
         use self::CommunicatorRelation::*;
         // FIXME: Yuck! These should be made const.
-        if i == ffi::RSMPI_IDENT {
+        if i == unsafe_extern_static!(ffi::RSMPI_IDENT) {
             return Identical;
-        } else if i == ffi::RSMPI_CONGRUENT {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_CONGRUENT) {
             return Congruent;
-        } else if i == ffi::RSMPI_SIMILAR {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_SIMILAR) {
             return Similar;
-        } else if i == ffi::RSMPI_UNEQUAL {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_UNEQUAL) {
             return Unequal;
         }
         panic!("Unknown communicator relation: {}", i)
@@ -439,7 +439,7 @@ impl<'a, C> Process<'a, C> where C: 'a + Communicator
 {
     #[allow(dead_code)]
     fn by_rank(c: &'a C, r: Rank) -> Option<Self> {
-        if r != ffi::RSMPI_PROC_NULL {
+        if r != unsafe_extern_static!(ffi::RSMPI_PROC_NULL) {
             Some(Process { comm: c, rank: r })
         } else {
             None
@@ -487,7 +487,7 @@ pub struct SystemGroup(MPI_Group);
 impl SystemGroup {
     /// An empty group
     pub fn empty() -> SystemGroup {
-        SystemGroup(ffi::RSMPI_GROUP_EMPTY)
+        SystemGroup(unsafe_extern_static!(ffi::RSMPI_GROUP_EMPTY))
     }
 }
 
@@ -512,7 +512,7 @@ impl Drop for UserGroup {
         unsafe {
             ffi::MPI_Group_free(&mut self.0);
         }
-        assert_eq!(self.0, ffi::RSMPI_GROUP_NULL);
+        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_GROUP_NULL));
     }
 }
 
@@ -636,7 +636,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         unsafe {
             ffi::MPI_Group_rank(self.as_raw(), &mut res);
         }
-        if res == ffi::RSMPI_UNDEFINED {
+        if res == unsafe_extern_static!(ffi::RSMPI_UNDEFINED) {
             None
         } else {
             Some(res)
@@ -657,7 +657,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         unsafe {
             ffi::MPI_Group_translate_ranks(self.as_raw(), 1, &rank, other.as_raw(), &mut res);
         }
-        if res == ffi::RSMPI_UNDEFINED {
+        if res == unsafe_extern_static!(ffi::RSMPI_UNDEFINED) {
             None
         } else {
             Some(res)
@@ -712,11 +712,11 @@ impl From<c_int> for GroupRelation {
     fn from(i: c_int) -> GroupRelation {
         use self::GroupRelation::*;
         // FIXME: Yuck! These should be made const.
-        if i == ffi::RSMPI_IDENT {
+        if i == unsafe_extern_static!(ffi::RSMPI_IDENT) {
             return Identical;
-        } else if i == ffi::RSMPI_SIMILAR {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_SIMILAR) {
             return Similar;
-        } else if i == ffi::RSMPI_UNEQUAL {
+        } else if i == unsafe_extern_static!(ffi::RSMPI_UNEQUAL) {
             return Unequal;
         }
         panic!("Unknown group relation: {}", i)


### PR DESCRIPTION
Use of extern static variables will be treated as unsafe code by rustc in the future.
This change makes rsmpi able to be compiled on the nightly as of Oct/1, 2016.

Edit: Sorry. This PR sucks because it makes rsmpi unable to be compiled on the stable due to unnecessary unsafes. Please just close it or keep it for the future.