### PR TITLE
Remove extra CI build command options and features in Cargo.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
 script:
   - cargo build -v && cargo test -v && sh ci/run-examples.sh
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      cargo clippy -v --features "clippy";
+      cargo clippy -v;
     fi
 
 before_deploy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,3 @@ rustc_version = "0.1"
 
 [features]
 default=[]
-lint = [ "clippy" ]
-clippy = []


### PR DESCRIPTION
This PR makes build on nightly with `clippy` successful.

While I'm not sure, `cargo clippy --features clippy` seems to choose empty feature `clippy = []` in `Cargo.toml` and then cause `unknown_lints` warnings. I don't know why the original author needed to make the `lint` feature in `Cargo.toml`, which is not used anymore.