### PR TITLE
Simplify and make Request safer

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,7 @@ fn main() {
         .emit_builtins()
         .no_unstable_rust()
         .hide_type("mpich_struct_mpi_long_double_int")
+        .hide_type("max_align_t") // https://github.com/servo/rust-bindgen/issues/550
         .generate()
         .unwrap();
 

--- a/examples/buffered.rs
+++ b/examples/buffered.rs
@@ -20,9 +20,9 @@ fn main() {
 
     let x = vec![3.1415f32; 1024];
     let mut y = vec![0.0; 1024];
-    {
-        let _rreq = WaitGuard::from(world.any_process().immediate_receive_into(&mut y[..]));
+    mpi::request::scope(|scope| {
+        let _rreq = WaitGuard::from(world.any_process().immediate_receive_into(scope, &mut y[..]));
         world.this_process().buffered_send(&x[..]);
-    }
+    });
     assert_eq!(x, y);
 }

--- a/examples/immediate_all_gather_varcount.rs
+++ b/examples/immediate_all_gather_varcount.rs
@@ -23,8 +23,10 @@ fn main() {
     let mut buf = vec![0; (size * (size - 1) / 2) as usize];
     {
         let mut partition = PartitionMut::new(&mut buf[..], counts, &displs[..]);
-        let req = world.immediate_all_gather_varcount_into(&msg[..], &mut partition);
-        req.wait();
+        mpi::request::scope(|scope| {
+            let req = world.immediate_all_gather_varcount_into(scope, &msg[..], &mut partition);
+            req.wait();
+        });
     }
 
     assert!(buf.iter().zip((0..size).flat_map(|r| (0..r))).all(|(&i, j)| i == j));

--- a/examples/immediate_all_to_all.rs
+++ b/examples/immediate_all_to_all.rs
@@ -11,7 +11,9 @@ fn main() {
     let u = vec![rank; size as usize];
     let mut v = vec![0; size as usize];
 
-    world.immediate_all_to_all_into(&u[..], &mut v[..]).wait();
+    mpi::request::scope(|scope| {
+        world.immediate_all_to_all_into(scope, &u[..], &mut v[..]).wait();
+    });
 
     println!("u: {:?}", u);
     println!("v: {:?}", v);

--- a/examples/immediate_broadcast.rs
+++ b/examples/immediate_broadcast.rs
@@ -15,7 +15,9 @@ fn main() {
     } else {
         x = 0_u64;
     }
-    root_process.immediate_broadcast_into(&mut x).wait();
+    mpi::request::scope(|scope| {
+        root_process.immediate_broadcast_into(scope, &mut x).wait();
+    });
     println!("Rank {} received value: {}.", world.rank(), x);
     assert_eq!(x, 1024);
     println!("");
@@ -28,7 +30,9 @@ fn main() {
     } else {
         a = std::iter::repeat(0_u64).take(n).collect::<Vec<_>>();
     }
-    root_process.immediate_broadcast_into(&mut a[..]).wait();
+    mpi::request::scope(|scope| {
+        root_process.immediate_broadcast_into(scope, &mut a[..]).wait();
+    });
     println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
     assert_eq!(&a[..], &[2, 4, 8, 16]);
 }

--- a/examples/immediate_gather_varcount.rs
+++ b/examples/immediate_gather_varcount.rs
@@ -27,12 +27,16 @@ fn main() {
         let mut buf = vec![0; (size * (size - 1) / 2) as usize];
         {
             let mut partition = PartitionMut::new(&mut buf[..], counts, &displs[..]);
-            root_process.immediate_gather_varcount_into_root(&msg[..], &mut partition).wait();
+            mpi::request::scope(|scope| {
+                root_process.immediate_gather_varcount_into_root(scope, &msg[..], &mut partition).wait();
+            })
         }
 
         assert!(buf.iter().zip((0..size).flat_map(|r| (0..r))).all(|(&i, j)| i == j));
         println!("{:?}", buf);
     } else {
-        root_process.immediate_gather_varcount_into(&msg[..]).wait();
+        mpi::request::scope(|scope| {
+            root_process.immediate_gather_varcount_into(scope, &msg[..]).wait();
+        });
     }
 }

--- a/examples/immediate_reduce.rs
+++ b/examples/immediate_reduce.rs
@@ -13,24 +13,32 @@ fn main() {
 
     if rank == root_rank {
         let mut sum: Rank = 0;
-        world.process_at_rank(root_rank)
-            .immediate_reduce_into_root(&rank, &mut sum, &SystemOperation::sum())
-            .wait();
+        mpi::request::scope(|scope| {
+            world.process_at_rank(root_rank)
+                .immediate_reduce_into_root(scope, &rank, &mut sum, &SystemOperation::sum())
+                .wait();
+        });
         assert_eq!(sum, size * (size - 1) / 2);
     } else {
-        world.process_at_rank(root_rank)
-            .immediate_reduce_into(&rank, &SystemOperation::sum())
-            .wait();
+        mpi::request::scope(|scope| {
+            world.process_at_rank(root_rank)
+                .immediate_reduce_into(scope, &rank, &SystemOperation::sum())
+                .wait();
+        });
     }
 
     let mut max: Rank = -1;
 
-    world.immediate_all_reduce_into(&rank, &mut max, &SystemOperation::max()).wait();
+    mpi::request::scope(|scope| {
+        world.immediate_all_reduce_into(scope, &rank, &mut max, &SystemOperation::max()).wait();
+    });
     assert_eq!(max, size - 1);
 
     let a = (0..size).collect::<Vec<_>>();
     let mut b: Rank = 0;
 
-    world.immediate_reduce_scatter_block_into(&a[..], &mut b, &SystemOperation::product()).wait();
+    mpi::request::scope(|scope| {
+        world.immediate_reduce_scatter_block_into(scope, &a[..], &mut b, &SystemOperation::product()).wait();
+    });
     assert_eq!(b, rank.pow(size as u32));
 }

--- a/examples/immediate_scan.rs
+++ b/examples/immediate_scan.rs
@@ -14,12 +14,16 @@ fn main() {
     let rank = world.rank();
 
     let mut x = 0;
-    world.immediate_scan_into(&rank, &mut x, &SystemOperation::sum()).wait();
+    mpi::request::scope(|scope| {
+        world.immediate_scan_into(scope, &rank, &mut x, &SystemOperation::sum()).wait();
+    });
     assert_eq!(x, (rank * (rank + 1)) / 2);
 
     let y = rank + 1;
     let mut z = 0;
-    world.immediate_exclusive_scan_into(&y, &mut z, &SystemOperation::product()).wait();
+    mpi::request::scope(|scope| {
+        world.immediate_exclusive_scan_into(scope, &y, &mut z, &SystemOperation::product()).wait();
+    });
     if rank > 0 {
         assert_eq!(z, fac(y - 1));
     }

--- a/examples/immediate_scatter.rs
+++ b/examples/immediate_scatter.rs
@@ -14,11 +14,15 @@ fn main() {
     let mut x = 0 as Rank;
     if rank == root_rank {
         let v = (0..size).collect::<Vec<_>>();
-        let req = root_process.immediate_scatter_into_root(&v[..], &mut x);
-        req.wait();
+        mpi::request::scope(|scope| {
+            let req = root_process.immediate_scatter_into_root(scope, &v[..], &mut x);
+            req.wait();
+        });
     } else {
-        let req = root_process.immediate_scatter_into(&mut x);
-        req.wait();
+        mpi::request::scope(|scope| {
+            let req = root_process.immediate_scatter_into(scope, &mut x);
+            req.wait();
+        });
     }
     assert_eq!(x, rank);
 }

--- a/examples/immediate_scatter_varcount.rs
+++ b/examples/immediate_scatter_varcount.rs
@@ -25,9 +25,13 @@ fn main() {
             Some(tmp)
         }).collect();
         let partition = Partition::new(&msg[..], counts, &displs[..]);
-        root_process.immediate_scatter_varcount_into_root(&partition, &mut buf[..]).wait();
+        mpi::request::scope(|scope| {
+            root_process.immediate_scatter_varcount_into_root(scope, &partition, &mut buf[..]).wait();
+        });
     } else {
-        root_process.immediate_scatter_varcount_into(&mut buf[..]).wait();
+        mpi::request::scope(|scope| {
+            root_process.immediate_scatter_varcount_into(scope, &mut buf[..]).wait();
+        });
     }
 
     assert!(buf.iter().zip((0..rank)).all(|(&i, j)| i == j));

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -13,26 +13,28 @@ fn main() {
     let previous_rank = if rank - 1 >= 0 { rank - 1 } else { size - 1 };
 
     let msg = vec![rank , 2 * rank, 4 * rank];
-    let _sreq = WaitGuard::from(world.process_at_rank(next_rank).immediate_send(&msg[..]));
+    mpi::request::scope(|scope| {
+        let _sreq = WaitGuard::from(world.process_at_rank(next_rank).immediate_send(scope, &msg[..]));
 
-    let (msg, status) = world.any_process().receive_vec();
+        let (msg, status) = world.any_process().receive_vec();
 
-    println!("Process {} got message {:?}.\nStatus is: {:?}", rank, msg, status);
-    let x = status.source_rank();
-    assert_eq!(x, previous_rank);
-    assert_eq!(vec![x, 2 * x, 4 * x], msg);
+        println!("Process {} got message {:?}.\nStatus is: {:?}", rank, msg, status);
+        let x = status.source_rank();
+        assert_eq!(x, previous_rank);
+        assert_eq!(vec![x, 2 * x, 4 * x], msg);
 
-    let root_rank = 0;
-    let root_process = world.process_at_rank(root_rank);
+        let root_rank = 0;
+        let root_process = world.process_at_rank(root_rank);
 
-    let mut a;
-    if world.rank() == root_rank {
-        a = vec![2, 4, 8, 16];
-        println!("Root broadcasting value: {:?}.", &a[..]);
-    } else {
-        a = vec![0; 4];
-    }
-    root_process.broadcast_into(&mut a[..]);
-    println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
-    assert_eq!(&a[..], &[2, 4, 8, 16]);
+        let mut a;
+        if world.rank() == root_rank {
+            a = vec![2, 4, 8, 16];
+            println!("Root broadcasting value: {:?}.", &a[..]);
+        } else {
+            a = vec![0; 4];
+        }
+        root_process.broadcast_into(&mut a[..]);
+        println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
+        assert_eq!(&a[..], &[2, 4, 8, 16]);
+    });
 }

--- a/examples/ready_send.rs
+++ b/examples/ready_send.rs
@@ -15,15 +15,15 @@ fn main() {
         world.process_at_rank(0).ready_send(&msg);
     } else {
         let mut v = vec![0u8; (size - 1) as usize];
-        {
+        mpi::request::scope(|scope| {
             let reqs = v.iter_mut().zip((1..)).map(
-                |(x, i)| { world.process_at_rank(i as Rank).immediate_receive_into(x) }
+                |(x, i)| { world.process_at_rank(i as Rank).immediate_receive_into(scope, x) }
             ).collect::<Vec<_>>();
             world.barrier();
             for req in reqs {
                 req.wait();
             }
-        }
+        });
         println!("Got message: {:?}", v);
         assert!(v.iter().zip((1..)).all(|(x, i)| { i == *x as usize }));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,6 @@ pub mod traits {
     pub use datatype::traits::*;
     pub use point_to_point::traits::*;
     pub use raw::traits::*;
-    pub use request::traits::*;
     pub use topology::traits::*;
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,13 +2,21 @@
 //!
 //! Non-blocking operations such as `immediate_send()` return request objects that borrow any
 //! buffers involved in the operation so as to ensure proper access restrictions. In order to
-//! release the borrowed buffers from the request objects, a completion operation such as `wait()`
-//! or `test()` must be used on the request object. To enforce this rule, the request objects
-//! implement a `Drop` bomb which will `panic!()` when a request object is dropped.
+//! release the borrowed buffers from the request objects, a completion operation such as
+//! [`wait()`](struct.Request.html#method.wait) or [`test()`](struct.Request.html#method.test) must
+//! be used on the request object.
 //!
-//! To handle request completion in a RAII style, requests can be wrapped in either `WaitGuard` or
-//! `CancelGuard` which will follow the respective policy for completing the operation upon being
-//! dropped instead of `panic!()`ing.
+//! **Note:** If the `Request` is dropped (as opposed to calling `wait` or `test` explicitly), the
+//! program will panic.
+//!
+//! To enforce this rule, every request object must be attached to some pre-existing
+//! [`Scope`](trait.Scope.html), which is usually created with [`scope`](fn.scope.html).  At the end
+//! of a `Scope`, all its remaining requests will be waited for until completion.
+//!
+//! To handle request completion in an RAII style, a request can be wrapped in either
+//! [`WaitGuard`](struct.WaitGuard.html) or [`CancelGuard`](struct.CancelGuard.html), which will
+//! follow the respective policy for completing the operation.  When the guard is dropped, the
+//! request will be automatically detached from its `Scope`.
 //!
 //! # Unfinished features
 //!
@@ -16,8 +24,10 @@
 //!   - Completion, `MPI_Waitany()`, `MPI_Waitall()`, `MPI_Waitsome()`,
 //!   `MPI_Testany()`, `MPI_Testall()`, `MPI_Testsome()`, `MPI_Request_get_status()`
 //! - **3.8**:
-//!   - Cancellation, `MPI_Cancel()`, `MPI_Test_cancelled()`
+//!   - Cancellation, `MPI_Test_cancelled()`
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::mem;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
@@ -28,16 +38,81 @@ use ffi::{MPI_Request, MPI_Status};
 use point_to_point::Status;
 use raw::traits::*;
 
-/// Request object traits
-pub mod traits {
-    pub use super::Request;
+/// Check if the request is `MPI_REQUEST_NULL`.
+fn is_null(request: MPI_Request) -> bool {
+    request == unsafe_extern_static!(ffi::RSMPI_REQUEST_NULL)
 }
 
-/// A request for a non-blocking operation
-pub trait Request: AsRaw<Raw = MPI_Request> + AsRawMut {
-    /// Returns true for a null request handle.
-    fn is_null(&self) -> bool {
-        self.as_raw() == unsafe_extern_static!(ffi::RSMPI_REQUEST_NULL)
+/// A request object for a non-blocking operation attached to a `Scope` with lifetime `'a`
+///
+/// The `Scope` is needed to ensure that all buffers associated request will outlive the request
+/// itself, even if the destructor of the request fails to run.
+///
+/// # Panics
+///
+/// Panics if the request object is dropped.  To prevent this, call `wait`, `wait_without_status`,
+/// or `test`.  Alternatively, wrap the request inside a `WaitGuard` or `CancelGuard`.
+///
+/// # Examples
+///
+/// See `examples/immediate.rs`
+///
+/// # Standard section(s)
+///
+/// 3.7.1
+#[must_use]
+#[derive(Debug)]
+pub struct Request<'a, S: Scope<'a> = StaticScope>(WaitGuard<'a, S>);
+
+unsafe impl<'a, S: Scope<'a>> AsRaw for Request<'a, S> {
+    type Raw = MPI_Request;
+    fn as_raw(&self) -> Self::Raw {
+        self.0.as_raw()
+    }
+}
+
+impl<'a, S: Scope<'a>> Drop for Request<'a, S> {
+    fn drop(&mut self) {
+        panic!("request was dropped without being completed");
+    }
+}
+
+impl<'a, S: Scope<'a>> From<WaitGuard<'a, S>> for Request<'a, S> {
+    fn from(guard: WaitGuard<'a, S>) -> Self {
+        Request(guard)
+    }
+}
+
+impl<'a, S: Scope<'a>> From<CancelGuard<'a, S>> for Request<'a, S> {
+    fn from(mut guard: CancelGuard<'a, S>) -> Self {
+        // unwrapping an object that implements Drop is tricky
+        Request(unsafe {
+            let inner = mem::replace(&mut guard.0, mem::uninitialized());
+            mem::forget(guard);
+            inner
+        })
+    }
+}
+
+impl<'a, S: Scope<'a>> Request<'a, S> {
+    /// Construct a request object from the raw MPI type.
+    ///
+    /// # Requirements
+    ///
+    /// - The request is a valid, active request.  It must not be `MPI_REQUEST_NULL`.
+    /// - The request must not be persistent.
+    /// - All buffers associated with the request must outlive `'a`.
+    /// - The request must not be registered with the given scope.
+    ///
+    pub unsafe fn from_raw(request: MPI_Request, scope: S) -> Self {
+        Request(WaitGuard::from_raw(request, scope))
+    }
+
+    /// Unregister the request object from its scope and deconstruct it into its raw parts.
+    ///
+    /// This is unsafe because the request may outlive its associated buffers.
+    pub unsafe fn into_raw(self) -> (MPI_Request, S) {
+        WaitGuard::from(self).into_raw()
     }
 
     /// Wait for an operation to finish.
@@ -51,22 +126,34 @@ pub trait Request: AsRaw<Raw = MPI_Request> + AsRawMut {
     /// # Standard section(s)
     ///
     /// 3.7.3
-    fn wait(mut self) -> Status
-        where Self: Sized
-    {
-        let mut status: MPI_Status = unsafe { mem::uninitialized() };
+    pub fn wait(self) -> Status {
         unsafe {
-            ffi::MPI_Wait(self.as_raw_mut(), &mut status);
+            let mut status: MPI_Status = mem::uninitialized();
+            self.0.raw_wait(Some(&mut status));
+            self.into_raw();
+            Status::from_raw(status)
         }
-        assert!(self.is_null());
-        mem::forget(self);
-        Status::from_raw(status)
+    }
+
+    /// Wait for an operation to finish, but don’t bother retrieving the `Status` information.
+    ///
+    /// Will block execution of the calling thread until the associated operation has finished.
+    ///
+    /// # Standard section(s)
+    ///
+    /// 3.7.3
+    pub fn wait_without_status(self) {
+        unsafe {
+            self.0.raw_wait(None);
+            self.into_raw();
+        }
     }
 
     /// Test whether an operation has finished.
     ///
-    /// If the operation has finished returns the `Status` otherwise returns the unfinished
+    /// If the operation has finished, `Status` is returned.  Otherwise returns the unfinished
     /// `Request`.
+    ///
     /// # Examples
     ///
     /// See `examples/immediate.rs`
@@ -74,24 +161,29 @@ pub trait Request: AsRaw<Raw = MPI_Request> + AsRawMut {
     /// # Standard section(s)
     ///
     /// 3.7.3
-    fn test(mut self) -> Result<Status, Self>
-        where Self: Sized
-    {
-        let mut status: MPI_Status = unsafe { mem::uninitialized() };
-        let mut flag: c_int = 0;
+    pub fn test(self) -> Result<Status, Self> {
         unsafe {
-            ffi::MPI_Test(self.as_raw_mut(), &mut flag, &mut status);
-        }
-        assert!(flag == 0 || self.is_null());
-        if flag != 0 {
-            mem::forget(self);
-            Ok(Status::from_raw(status))
-        } else {
-            Err(self)
+            let mut status: MPI_Status = mem::uninitialized();
+            let mut flag: c_int = mem::uninitialized();
+            let mut request = self.as_raw();
+            ffi::MPI_Test(&mut request, &mut flag, &mut status);
+            if flag != 0 {
+                assert!(is_null(request));  // persistent requests are not supported
+                self.into_raw();
+                Ok(Status::from_raw(status))
+            } else {
+                Err(self)
+            }
         }
     }
 
     /// Cancel an operation.
+    ///
+    /// The MPI implementation is not guaranteed to fulfill this operation.  It may not even be
+    /// valid for certain types of requests.  In the future, the MPI forum may [deprecate
+    /// cancellation of sends][mpi26] entirely.
+    ///
+    /// [mpi26]: https://github.com/mpi-forum/mpi-issues/issues/26
     ///
     /// # Examples
     ///
@@ -100,236 +192,229 @@ pub trait Request: AsRaw<Raw = MPI_Request> + AsRawMut {
     /// # Standard section(s)
     ///
     /// 3.8.4
-    fn cancel(mut self)
-        where Self: Sized
+    pub fn cancel(&self) {
+        self.0.cancel();
+    }
+
+    /// Reduce the scope of a request.
+    pub fn shrink_scope_to<'b, S2>(self, scope: S2) -> Request<'b, S2>
+        where 'a: 'b, S2: Scope<'b>
     {
         unsafe {
-            ffi::MPI_Cancel(self.as_raw_mut());
-            ffi::MPI_Request_free(self.as_raw_mut());
+            let (request, _) = self.into_raw();
+            Request::from_raw(request, scope)
         }
-        assert!(self.is_null());
-        mem::forget(self);
-    }
-}
-
-/// A request object for an non-blocking operation that holds no references
-///
-/// # Examples
-///
-/// See `examples/immediate_barrier.rs`
-///
-/// # Standard section(s)
-///
-/// 3.7.1
-#[must_use]
-pub struct PlainRequest(MPI_Request);
-
-impl PlainRequest {
-    /// Construct a request object from the raw MPI type
-    pub fn from_raw(request: MPI_Request) -> PlainRequest {
-        PlainRequest(request)
-    }
-}
-
-unsafe impl AsRaw for PlainRequest {
-    type Raw = MPI_Request;
-    fn as_raw(&self) -> Self::Raw {
-        self.0
-    }
-}
-
-unsafe impl AsRawMut for PlainRequest {
-    fn as_raw_mut(&mut self) -> *mut <Self as AsRaw>::Raw {
-        &mut (self.0)
-    }
-}
-
-impl Request for PlainRequest {}
-
-impl Drop for PlainRequest {
-    fn drop(&mut self) {
-        assert!(self.is_null(),
-                "request dropped without ascertaining completion.");
-    }
-}
-
-/// A request object for a non-blocking operation that holds a reference to an immutable buffer
-///
-/// # Examples
-///
-/// See `examples/immediate.rs`
-///
-/// # Standard section(s)
-///
-/// 3.7.1
-#[must_use]
-pub struct ReadRequest<'b, Buf: 'b + ?Sized>(MPI_Request, PhantomData<&'b Buf>);
-
-impl<'b, Buf: 'b + ?Sized> ReadRequest<'b, Buf> {
-    /// Construct a request object from the raw MPI type
-    pub fn from_raw(request: MPI_Request, _: &'b Buf) -> ReadRequest<'b, Buf> {
-        ReadRequest(request, PhantomData)
-    }
-}
-
-unsafe impl<'b, Buf: 'b + ?Sized> AsRaw for ReadRequest<'b, Buf> {
-    type Raw = MPI_Request;
-    fn as_raw(&self) -> Self::Raw {
-        self.0
-    }
-}
-
-unsafe impl<'b, Buf: 'b + ?Sized> AsRawMut for ReadRequest<'b, Buf> {
-    fn as_raw_mut(&mut self) -> *mut <Self as AsRaw>::Raw {
-        &mut (self.0)
-    }
-}
-
-impl<'b, Buf: 'b + ?Sized> Request for ReadRequest<'b, Buf> {}
-
-impl<'b, Buf: 'b + ?Sized> Drop for ReadRequest<'b, Buf> {
-    fn drop(&mut self) {
-        assert!(self.is_null(),
-                "read request dropped without ascertaining completion.");
-    }
-}
-
-/// A request object for a non-blocking operation that holds a reference to a mutable buffer
-///
-/// # Examples
-///
-/// See `examples/immediate.rs`
-///
-/// # Standard section(s)
-///
-/// 3.7.1
-#[must_use]
-pub struct WriteRequest<'b, Buf: 'b + ?Sized>(MPI_Request, PhantomData<&'b mut Buf>);
-
-impl<'b, Buf: 'b + ?Sized> WriteRequest<'b, Buf> {
-    /// Construct a request object from the raw MPI type
-    pub fn from_raw(request: MPI_Request, _: &'b Buf) -> WriteRequest<'b, Buf> {
-        WriteRequest(request, PhantomData)
-    }
-}
-
-unsafe impl<'b, Buf: 'b + ?Sized> AsRaw for WriteRequest<'b, Buf> {
-    type Raw = MPI_Request;
-    fn as_raw(&self) -> Self::Raw {
-        self.0
-    }
-}
-
-unsafe impl<'b, Buf: 'b + ?Sized> AsRawMut for WriteRequest<'b, Buf> {
-    fn as_raw_mut(&mut self) -> *mut <Self as AsRaw>::Raw {
-        &mut (self.0)
-    }
-}
-
-impl<'b, Buf: 'b + ?Sized> Request for WriteRequest<'b, Buf> {}
-
-impl<'b, Buf: 'b + ?Sized> Drop for WriteRequest<'b, Buf> {
-    fn drop(&mut self) {
-        assert!(self.is_null(),
-                "write request dropped without ascertaining completion.");
-    }
-}
-
-/// A request object for a non-blocking operation that holds a reference to a mutable and an
-/// immutable buffer
-///
-/// # Examples
-///
-/// See `examples/immediate_gather.rs`
-///
-/// # Standard section(s)
-///
-/// 3.7.1
-#[must_use]
-pub struct ReadWriteRequest<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized>(MPI_Request,
-                                                                    PhantomData<&'s S>,
-                                                                    PhantomData<&'r mut R>);
-
-impl<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized> ReadWriteRequest<'s, 'r, S, R> {
-    /// Construct a request object from the raw MPI type
-    pub fn from_raw(request: MPI_Request, _: &'s S, _: &'r R) -> ReadWriteRequest<'s, 'r, S, R> {
-        ReadWriteRequest(request, PhantomData, PhantomData)
-    }
-}
-
-unsafe impl<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized> AsRaw for ReadWriteRequest<'s, 'r, S, R> {
-    type Raw = MPI_Request;
-    fn as_raw(&self) -> Self::Raw {
-        self.0
-    }
-}
-
-unsafe impl<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized> AsRawMut for ReadWriteRequest<'s, 'r, S, R> {
-    fn as_raw_mut(&mut self) -> *mut <Self as AsRaw>::Raw {
-        &mut (self.0)
-    }
-}
-
-impl<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized> Request for ReadWriteRequest<'s, 'r, S, R> {}
-
-impl<'s, 'r, S: 's + ?Sized, R: 'r + ?Sized> Drop for ReadWriteRequest<'s, 'r, S, R> {
-    fn drop(&mut self) {
-        assert!(self.is_null(),
-                "read-write request dropped without ascertaining completion.");
     }
 }
 
 /// Guard object that waits for the completion of an operation when it is dropped
 ///
-/// # Examples
-///
-/// See `examples/immediate.rs`
-pub struct WaitGuard<Req>(Option<Req>) where Req: Request;
-
-impl<Req> Drop for WaitGuard<Req> where Req: Request
-{
-    fn drop(&mut self) {
-        self.0.take().map(|mut req| {
-            unsafe {
-                ffi::MPI_Wait(req.as_raw_mut(), ffi::RSMPI_STATUS_IGNORE);
-            }
-            assert!(req.is_null());
-            mem::forget(req);
-        });
-    }
-}
-
-impl<Req> From<Req> for WaitGuard<Req> where Req: Request
-{
-    fn from(req: Req) -> WaitGuard<Req> {
-        WaitGuard(Some(req))
-    }
-}
-
-/// Guard object that cancels an operation when it is dropped
+/// The guard can be constructed or deconstructed using the `From` and `Into` traits.
 ///
 /// # Examples
 ///
 /// See `examples/immediate.rs`
-pub struct CancelGuard<Req>(Option<Req>) where Req: Request;
+#[derive(Debug)]
+pub struct WaitGuard<'a, S: Scope<'a> = StaticScope> {
+    request: MPI_Request,
+    scope: S,
+    phantom: PhantomData<RefCell<&'a ()>>,
+}
 
-impl<Req> Drop for CancelGuard<Req> where Req: Request
-{
+impl<'a, S: Scope<'a>> Drop for WaitGuard<'a, S> {
     fn drop(&mut self) {
-        self.0.take().map(|mut req| {
-            unsafe {
-                ffi::MPI_Cancel(req.as_raw_mut());
-                ffi::MPI_Request_free(req.as_raw_mut());
-            }
-            assert!(req.is_null());
-            mem::forget(req);
-        });
+        unsafe {
+            self.raw_wait(None);
+            self.scope.unregister(&self.as_raw());
+        }
     }
 }
 
-impl<Req> From<Req> for CancelGuard<Req> where Req: Request
-{
-    fn from(req: Req) -> CancelGuard<Req> {
-        CancelGuard(Some(req))
+unsafe impl<'a, S: Scope<'a>> AsRaw for WaitGuard<'a, S> {
+    type Raw = MPI_Request;
+    fn as_raw(&self) -> Self::Raw {
+        self.request
     }
+}
+
+impl<'a, S: Scope<'a>> From<Request<'a, S>> for WaitGuard<'a, S> {
+    fn from(mut req: Request<'a, S>) -> Self {
+        unsafe {
+            let inner = mem::replace(&mut req.0, mem::uninitialized());
+            mem::forget(req);
+            inner
+        }
+    }
+}
+
+impl<'a, S: Scope<'a>> WaitGuard<'a, S> {
+    /// Construct a request object from the raw MPI type.
+    ///
+    /// # Requirements
+    ///
+    /// - The request is a valid, active request.  It must not be `MPI_REQUEST_NULL`.
+    /// - The request must not be persistent.
+    /// - All buffers associated with the request must outlive `'a`.
+    /// - The request must not be registered with the given scope.
+    ///
+    unsafe fn from_raw(request: MPI_Request, scope: S) -> Self {
+        debug_assert!(!is_null(request));
+        scope.register(request);
+        WaitGuard { request: request, scope: scope, phantom: Default::default() }
+    }
+
+    /// Unregister the request object from its scope and deconstruct it into its raw parts.
+    ///
+    /// This is unsafe because the request may outlive its associated buffers.
+    unsafe fn into_raw(mut self) -> (MPI_Request, S) {
+        let request = self.as_raw();
+        let scope = mem::replace(&mut self.scope, mem::uninitialized());
+        mem::replace(&mut self.phantom, mem::uninitialized());
+        mem::forget(self);
+        scope.unregister(&request);
+        (request, scope)
+    }
+
+    /// Wait for the request to finish.
+    ///
+    /// This is unsafe because `.request` is no longer valid afterwards.  This function should only
+    /// be called if the caller calls `into_raw` afterward and forgets the request.
+    unsafe fn raw_wait(&self, status: Option<&mut MPI_Status>) {
+        let mut request = self.as_raw();
+        let status = match status {
+            Some(r) => r,
+            None => ffi::RSMPI_STATUS_IGNORE,
+        };
+        ffi::MPI_Wait(&mut request, status);
+        assert!(is_null(request));      // persistent requests are not supported
+    }
+
+    fn cancel(&self) {
+        let mut request = self.as_raw();
+        unsafe {
+            ffi::MPI_Cancel(&mut request);
+        }
+    }
+}
+
+/// Guard object that tries to cancel and waits for the completion of an operation when it is
+/// dropped
+///
+/// The guard can be constructed or deconstructed using the `From` and `Into` traits.
+///
+/// # Examples
+///
+/// See `examples/immediate.rs`
+#[derive(Debug)]
+pub struct CancelGuard<'a, S: Scope<'a> = StaticScope>(WaitGuard<'a, S>);
+
+impl<'a, S: Scope<'a>> Drop for CancelGuard<'a, S> {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+impl<'a, S: Scope<'a>> From<Request<'a, S>> for CancelGuard<'a, S> {
+    fn from(req: Request<'a, S>) -> Self {
+        CancelGuard(WaitGuard::from(req))
+    }
+}
+
+/// A common interface for [`LocalScope`](struct.LocalScope.html) and
+/// [`StaticScope`](struct.StaticScope.html)
+///
+/// This trait is an implementation detail.  You shouldn’t have to use or implement this trait.
+pub unsafe trait Scope<'a> {
+    /// Registers the request with the scope.
+    unsafe fn register(&self, request: MPI_Request);
+
+    /// Unregisters the request from the scope.
+    unsafe fn unregister(&self, request: &MPI_Request);
+}
+
+/// The scope that lasts as long as the entire execution of the program
+///
+/// Unlike `LocalScope<'a>`, `StaticScope` does not require any bookkeeping on the requests as every
+/// request associated with a `StaticScope` can live as long as they please.
+///
+/// A `StaticScope` can be created simply by calling the `StaticScope` constructor.
+///
+/// # Invariant
+///
+/// For any `Request` attached to a `StaticScope`, its associated buffers must be `'static`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct StaticScope;
+
+unsafe impl Scope<'static> for StaticScope {
+    unsafe fn register(&self, _: MPI_Request) {}
+
+    unsafe fn unregister(&self, _: &MPI_Request) {}
+}
+
+/// A temporary scope that lasts no more than the lifetime `'a`
+///
+/// Use `LocalScope` for to perform requests with temporary buffers.
+///
+/// To obtain a `LocalScope`, use the [`scope`](fn.scope.html) function.
+///
+/// # Invariant
+///
+/// For any `Request` attached to a `LocalScope<'a>`, its associated buffers must outlive `'a`.
+#[derive(Debug)]
+pub struct LocalScope<'a> {
+    requests: RefCell<HashSet<MPI_Request>>,
+    phantom: PhantomData<RefCell<&'a ()>>, // RefCell needed to ensure 'a is invariant
+}
+
+impl<'a> Drop for LocalScope<'a> {
+    fn drop(&mut self) {
+        for &request in &*self.requests.borrow() {
+            unsafe {
+                let _ = WaitGuard::from_raw(request, StaticScope);
+            }
+        }
+    }
+}
+
+unsafe impl<'a, 'b> Scope<'a> for &'b LocalScope<'a> {
+    unsafe fn register(&self, request: MPI_Request) {
+        if !self.requests.borrow_mut().insert(request) {
+            panic!("request already registered");
+        }
+    }
+
+    unsafe fn unregister(&self, request: &MPI_Request) {
+        if !self.requests.borrow_mut().remove(request) {
+            panic!("can't unregister a request that wasn't registered");
+        }
+    }
+}
+
+/// Used to create a [`LocalScope`](struct.LocalScope.html)
+///
+/// The function creates a `LocalScope` and then passes it into the given
+/// closure as an argument.
+///
+/// For safety reasons, all variables and buffers associated with a request
+/// must exist *outside* the scope to which the request is attached.
+///
+/// It is typically used like this:
+///
+/// ```
+/// /* declare variables and buffers here ... */
+/// mpi::request::scope(|scope| {
+///     /* perform sends and/or receives using 'scope' */
+/// });
+/// /* when scope ends, all associated requests are automatically waited for */
+/// ```
+///
+/// # Examples
+///
+/// See `examples/immediate.rs`
+pub fn scope<'a, F, R>(f: F) -> R
+    where F: FnOnce(&LocalScope<'a>) -> R {
+    f(&LocalScope {
+        requests: Default::default(),
+        phantom: Default::default(),
+    })
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -114,8 +114,8 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     }
 
     /// Wait for the request to finish and unregister the request object from its scope.
-    ///
-    /// This is unsafe because afterward the request is left in an unspecified but droppable state.
+    /// If provided, the status is written to the referent of the given reference.
+    /// The referent `MPI_Status` object is never read.
     fn wait_with(self, status: Option<&mut MPI_Status>) {
         unsafe {
             let (mut request, _) = self.into_raw();
@@ -140,11 +140,9 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// 3.7.3
     pub fn wait(self) -> Status {
-        unsafe {
-            let mut status: MPI_Status = mem::uninitialized();
-            self.wait_with(Some(&mut status));
-            Status::from_raw(status)
-        }
+        let mut status: MPI_Status = unsafe { mem::uninitialized() };
+        self.wait_with(Some(&mut status));
+        Status::from_raw(status)
     }
 
     /// Wait for an operation to finish, but don’t bother retrieving the `Status` information.


### PR DESCRIPTION
Created two kinds of `Scope` objects:

  - `LocalScope` to track `Request`s with arbitrary lifetime `'a`
  - `StaticScope` (no bookkeeping, but only `'static` `Request`s)

The `Request` trait has been squashed into a single `Request<S>` data type, where `S` is the type of scope that this `Request` is associated with.

Fixes #17.

---

  - [x] Generalize methods over `Scope`.
  - [x] There's no way to transfer from an outer `LocalScope` to an inner `LocalScope`.
  - ~~It would be nice to generalize `Buffer` to allow things like `Rc`, which would be compatible with `StaticScope`.~~ (WIP: https://github.com/bsteinb/rsmpi/compare/Rufflewind:bindgen-hack...Rufflewind:buffer)