### PR TITLE
Make abort return !

### DIFF
--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1373,7 +1373,7 @@ impl Operation for SystemOperation {}
 ///
 /// # Examples
 ///
-/// See `examples/redure.rs`
+/// See `examples/reduce.rs`
 ///
 /// # Standard section(s)
 ///

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -19,7 +19,7 @@
 //! - **6.8**: Naming objects
 //! - **7**: Process topologies
 //! - **Parts of sections**: 8, 10, 12
-use std::mem;
+use std::{mem, process};
 use std::os::raw::c_int;
 
 use super::Tag;
@@ -385,10 +385,11 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Standard section(s)
     ///
     /// 8.7
-    fn abort(&self, errorcode: c_int) {
+    fn abort(&self, errorcode: c_int) -> ! {
         unsafe {
             ffi::MPI_Abort(self.as_raw(), errorcode);
         }
+        process::abort();
     }
 }
 


### PR DESCRIPTION
The `!` type informs Rust that any code that follows is unreachable, which is useful because the user is no longer obligated to return anything afterward.  To do this, `process::abort()` was added to `MPI_Abort`.  It also makes sure the program dies even if `MPI_Abort` doesn’t kill the program (which shouldn't ever happen).