### PR TITLE
Add support for user-defined operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
       - gfortran
       # bindgen dependency
       - libclang-3.9-dev
+      # libffi dependency
+      - texinfo
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 
 [dependencies]
 conv = "0.3"
+libffi = "0.6.0"
 
 [build-dependencies]
 gcc = "0.3"

--- a/examples/immediate_reduce.rs
+++ b/examples/immediate_reduce.rs
@@ -3,7 +3,7 @@ extern crate mpi;
 
 use mpi::traits::*;
 use mpi::topology::Rank;
-use mpi::collective::SystemOperation;
+use mpi::collective::{SystemOperation, UserOperation};
 
 fn main() {
     let universe = mpi::initialize().unwrap();
@@ -16,14 +16,14 @@ fn main() {
         let mut sum: Rank = 0;
         mpi::request::scope(|scope| {
             world.process_at_rank(root_rank)
-                .immediate_reduce_into_root(scope, &rank, &mut sum, &SystemOperation::sum())
+                .immediate_reduce_into_root(scope, &rank, &mut sum, SystemOperation::sum())
                 .wait();
         });
         assert_eq!(sum, size * (size - 1) / 2);
     } else {
         mpi::request::scope(|scope| {
             world.process_at_rank(root_rank)
-                .immediate_reduce_into(scope, &rank, &SystemOperation::sum())
+                .immediate_reduce_into(scope, &rank, SystemOperation::sum())
                 .wait();
         });
     }
@@ -31,7 +31,7 @@ fn main() {
     let mut max: Rank = -1;
 
     mpi::request::scope(|scope| {
-        world.immediate_all_reduce_into(scope, &rank, &mut max, &SystemOperation::max()).wait();
+        world.immediate_all_reduce_into(scope, &rank, &mut max, SystemOperation::max()).wait();
     });
     assert_eq!(max, size - 1);
 
@@ -39,7 +39,20 @@ fn main() {
     let mut b: Rank = 0;
 
     mpi::request::scope(|scope| {
-        world.immediate_reduce_scatter_block_into(scope, &a[..], &mut b, &SystemOperation::product()).wait();
+        world.immediate_reduce_scatter_block_into(scope, &a[..], &mut b, SystemOperation::product()).wait();
     });
     assert_eq!(b, rank.pow(size as u32));
+
+    let op = UserOperation::commutative(|x, y| {
+        let x: &[Rank] = x.downcast().unwrap();
+        let y: &mut [Rank] = y.downcast().unwrap();
+        for (&x_i, y_i) in x.iter().zip(y) {
+            *y_i += x_i;
+        }
+    });
+    let mut c = 0;
+    mpi::request::scope(|scope| {
+        world.immediate_all_reduce_into(scope, &rank, &mut c, &op).wait();
+    });
+    assert_eq!(c, size * (size - 1) / 2);
 }

--- a/examples/immediate_scan.rs
+++ b/examples/immediate_scan.rs
@@ -16,14 +16,14 @@ fn main() {
 
     let mut x = 0;
     mpi::request::scope(|scope| {
-        world.immediate_scan_into(scope, &rank, &mut x, &SystemOperation::sum()).wait();
+        world.immediate_scan_into(scope, &rank, &mut x, SystemOperation::sum()).wait();
     });
     assert_eq!(x, (rank * (rank + 1)) / 2);
 
     let y = rank + 1;
     let mut z = 0;
     mpi::request::scope(|scope| {
-        world.immediate_exclusive_scan_into(scope, &y, &mut z, &SystemOperation::product()).wait();
+        world.immediate_exclusive_scan_into(scope, &y, &mut z, SystemOperation::product()).wait();
     });
     if rank > 0 {
         assert_eq!(z, fac(y - 1));

--- a/examples/reduce.rs
+++ b/examples/reduce.rs
@@ -4,7 +4,7 @@ extern crate mpi;
 
 use mpi::traits::*;
 use mpi::topology::Rank;
-use mpi::collective::{self, SystemOperation};
+use mpi::collective::{self, SystemOperation, UserOperation};
 
 fn main() {
     let universe = mpi::initialize().unwrap();
@@ -15,35 +15,45 @@ fn main() {
 
     if rank == root_rank {
         let mut sum: Rank = 0;
-        world.process_at_rank(root_rank).reduce_into_root(&rank, &mut sum, &SystemOperation::sum());
+        world.process_at_rank(root_rank).reduce_into_root(&rank, &mut sum, SystemOperation::sum());
         assert_eq!(sum, size * (size - 1) / 2);
     } else {
-        world.process_at_rank(root_rank).reduce_into(&rank, &SystemOperation::sum());
+        world.process_at_rank(root_rank).reduce_into(&rank, SystemOperation::sum());
     }
 
     let mut max: Rank = -1;
 
-    world.all_reduce_into(&rank, &mut max, &SystemOperation::max());
+    world.all_reduce_into(&rank, &mut max, SystemOperation::max());
     assert_eq!(max, size - 1);
 
     let a: u64 = 0b0000111111110000;
     let b: u64 = 0b0011110000111100;
 
     let mut c = b;
-    collective::reduce_local_into(&a, &mut c, &SystemOperation::bitwise_and());
+    collective::reduce_local_into(&a, &mut c, SystemOperation::bitwise_and());
     assert_eq!(c, 0b0000110000110000);
 
     let mut d = b;
-    collective::reduce_local_into(&a, &mut d, &SystemOperation::bitwise_or());
+    collective::reduce_local_into(&a, &mut d, SystemOperation::bitwise_or());
     assert_eq!(d, 0b0011111111111100);
 
     let mut e = b;
-    collective::reduce_local_into(&a, &mut e, &SystemOperation::bitwise_xor());
+    collective::reduce_local_into(&a, &mut e, SystemOperation::bitwise_xor());
     assert_eq!(e, 0b0011001111001100);
 
     let f = (0..size).collect::<Vec<_>>();
     let mut g: Rank = 0;
 
-    world.reduce_scatter_block_into(&f[..], &mut g, &SystemOperation::product());
+    world.reduce_scatter_block_into(&f[..], &mut g, SystemOperation::product());
     assert_eq!(g, rank.pow(size as u32));
+
+    let mut h = 0;
+    world.all_reduce_into(&(rank + 1), &mut h, &UserOperation::commutative(|x, y| {
+        let x: &[Rank] = x.downcast().unwrap();
+        let y: &mut [Rank] = y.downcast().unwrap();
+        for (&x_i, y_i) in x.iter().zip(y) {
+            *y_i += x_i;
+        }
+    }));
+    assert_eq!(h, size * (size + 1) / 2);
 }

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1515,14 +1515,19 @@ impl<'a> UserOperation<'a> {
 }
 
 unsafe fn wrapper<F>(function: &F,
-                     invec: *mut c_void,
-                     inoutvec: *mut c_void,
+                     mut invec: *mut c_void,
+                     mut inoutvec: *mut c_void,
                      len: *mut c_int,
                      datatype: *mut ffi::MPI_Datatype)
     where F: Fn(DynBuffer, DynBufferMut)
 {
     let len = *len;
     let datatype = DatatypeRef::from_raw(*datatype);
+    if len == 0 {
+        // precautionary measure: ensure pointers are not null
+        invec = [].as_mut_ptr();
+        inoutvec = [].as_mut_ptr();
+    }
     function(DynBuffer::from_raw(invec, len, datatype),
              DynBufferMut::from_raw(inoutvec, len, datatype));
 }

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -6,7 +6,6 @@
 //!
 //! - **5.8**: All-to-all, `MPI_Alltoallw()`
 //! - **5.9**: Global reduction operations, `MPI_Op_create()`, `MPI_Op_free()`,
-//! `MPI_Op_commutative()`
 //! - **5.10**: Reduce-scatter, `MPI_Reduce_scatter()`
 //! - **5.12**: Nonblocking collective operations,
 //! `MPI_Ialltoallw()`, `MPI_Ireduce_scatter()`
@@ -1321,7 +1320,20 @@ impl<'a, C: 'a + Communicator> Root for Process<'a, C> {
 }
 
 /// An operation to be used in a reduction or scan type operation, e.g. `MPI_SUM`
-pub trait Operation: AsRaw<Raw = MPI_Op> { }
+pub trait Operation: AsRaw<Raw = MPI_Op> {
+    /// Returns whether the operation is commutative.
+    ///
+    /// # Standard section(s)
+    ///
+    /// 5.9.7
+    fn is_commutative(&self) -> bool {
+        unsafe {
+            let mut commute = 0;
+            ffi::MPI_Op_commutative(self.as_raw(), &mut commute);
+            commute != 0
+        }
+    }
+}
 impl<'a, T: 'a + Operation> Operation for &'a T {}
 
 /// A built-in operation like `MPI_SUM`

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -91,17 +91,7 @@ impl<'a> DatatypeRef<'a> {
 /// # Standard section(s)
 ///
 /// 3.2.2
-#[derive(Copy, Clone)]
-pub struct SystemDatatype(MPI_Datatype);
-
-unsafe impl AsRaw for SystemDatatype {
-    type Raw = MPI_Datatype;
-    fn as_raw(&self) -> Self::Raw {
-        self.0
-    }
-}
-
-impl Datatype for SystemDatatype {}
+pub type SystemDatatype = DatatypeRef<'static>;
 
 /// A direct equivalence exists between the implementing type and an MPI datatype
 ///
@@ -120,7 +110,7 @@ macro_rules! equivalent_system_datatype {
         unsafe impl Equivalence for $rstype {
             type Out = SystemDatatype;
             fn equivalent_datatype() -> Self::Out {
-                SystemDatatype(unsafe_extern_static!($mpitype))
+                unsafe { DatatypeRef::from_raw($mpitype) }
             }
         }
     )

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -510,10 +510,12 @@ impl<'a> DynBuffer<'a> {
         }
     }
 
-    /// Creates a buffer from its raw components.  The buffer must remain valid for `'a`.
+    /// Creates a buffer from its raw components.  The buffer must remain valid for `'a` and the
+    /// pointer must not be null.
     pub unsafe fn from_raw<T>(ptr: *const T,
                               len: Count,
                               datatype: DatatypeRef<'a>) -> Self {
+        debug_assert!(!ptr.is_null());
         Self { ptr: ptr as _, len, datatype }
     }
 
@@ -596,10 +598,12 @@ impl<'a> DynBufferMut<'a> {
         }
     }
 
-    /// Creates a buffer from its raw components.  The buffer must remain valid for `'a`.
+    /// Creates a buffer from its raw components.  The buffer must remain valid for `'a` and the
+    /// pointer must not be null.
     pub unsafe fn from_raw<T>(ptr: *mut T,
                               len: Count,
                               datatype: DatatypeRef<'a>) -> Self {
+        debug_assert!(!ptr.is_null());
         Self { ptr: ptr as _, len, datatype }
     }
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -43,6 +43,7 @@
 
 use std::mem;
 use std::borrow::Borrow;
+use std::marker::PhantomData;
 use std::os::raw::c_void;
 
 use conv::ConvUtil;
@@ -58,6 +59,31 @@ use raw::traits::*;
 pub mod traits {
     pub use super::{Equivalence, Datatype, AsDatatype, Collection, Pointer, PointerMut, Buffer,
                     BufferMut, Partitioned, PartitionedBuffer, PartitionedBufferMut};
+}
+
+/// A reference to an MPI data type.
+///
+/// This is similar to a raw `MPI_Datatype` but is guaranteed to be a valid for `'a`.
+#[derive(Copy, Clone, Debug)]
+pub struct DatatypeRef<'a> {
+    datatype: MPI_Datatype,
+    phantom: PhantomData<&'a ()>,
+}
+
+unsafe impl<'a> AsRaw for DatatypeRef<'a> {
+    type Raw = MPI_Datatype;
+    fn as_raw(&self) -> Self::Raw {
+        self.datatype
+    }
+}
+
+impl<'a> Datatype for DatatypeRef<'a> {}
+
+impl<'a> DatatypeRef<'a> {
+    /// Wrap a raw handle.  The handle must remain valid for `'a`.
+    pub unsafe fn from_raw(datatype: MPI_Datatype) -> Self {
+        Self { datatype, phantom: PhantomData }
+    }
 }
 
 /// A system datatype, e.g. `MPI_FLOAT`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@
 use std::os::raw::c_int;
 
 extern crate conv;
+extern crate libffi;
 
 /// The raw C language MPI API
 ///


### PR DESCRIPTION
It’s not pretty …  Because of how MPI_User_function is defined, it doesn’t give us a clean way attach/access arbitrary user data.  As a result, we have to pull in libffi to hack our way through.

- Add `BorrowedDatatype`, a thin wrapper over `MPI_Datatype` (feel free to bikeshed on the name)
- Redefine `SystemDatatype = BorrowedDatatype<'static>`
- Add `DynBuffer[Mut]`
- Add `is_commutative`
- Add `UserOperation`