### PR TITLE
Be explicit that these are the sections of the MPI standard

### DIFF
--- a/src/collective.rs
+++ b/src/collective.rs
@@ -42,7 +42,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/barrier.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.3
     fn barrier(&self) {
@@ -62,7 +62,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/all_gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.7
     fn all_gather_into<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -92,7 +92,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/all_gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.7
     fn all_gather_varcount_into<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -119,7 +119,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/all_to_all.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.8
     fn all_to_all_into<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -143,7 +143,7 @@ pub trait CommunicatorCollectives: Communicator {
     /// The count of elements to send and receive to and from each process can vary and is specified
     /// using `Partitioned`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.8
     fn all_to_all_varcount_into<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -170,7 +170,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.9.6
     fn all_reduce_into<S: ?Sized, R: ?Sized, O>(&self, sendbuf: &S, recvbuf: &mut R, op: O)
@@ -196,7 +196,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.10.1
     fn reduce_scatter_block_into<S: ?Sized, R: ?Sized, O>(&self,
@@ -225,7 +225,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/scan.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.11.1
     fn scan_into<S: ?Sized, R: ?Sized, O>(&self, sendbuf: &S, recvbuf: &mut R, op: O)
@@ -250,7 +250,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/scan.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.11.2
     fn exclusive_scan_into<S: ?Sized, R: ?Sized, O>(&self, sendbuf: &S, recvbuf: &mut R, op: O)
@@ -277,7 +277,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_barrier.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.1
     fn immediate_barrier(&self) -> Request<'static> {
@@ -295,7 +295,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_all_gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.5
     fn immediate_all_gather_into<'a, Sc, S: ?Sized, R: ?Sized>(&self,
@@ -329,7 +329,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_all_gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.5
     fn immediate_all_gather_varcount_into<'a, Sc, S: ?Sized, R: ?Sized>
@@ -363,7 +363,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_all_to_all.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.6
     fn immediate_all_to_all_into<'a, Sc, S: ?Sized, R: ?Sized>(&self,
@@ -392,7 +392,7 @@ pub trait CommunicatorCollectives: Communicator {
 
     /// Initiate non-blocking all-to-all communication.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.6
     fn immediate_all_to_all_varcount_into<'a, Sc, S: ?Sized, R: ?Sized>
@@ -428,7 +428,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.8
     fn immediate_all_reduce_into<'a, Sc, S: ?Sized, R: ?Sized, O>
@@ -464,7 +464,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.9
     fn immediate_reduce_scatter_block_into<'a, Sc, S: ?Sized, R: ?Sized, O>
@@ -500,7 +500,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_scan.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.11
     fn immediate_scan_into<'a, Sc, S: ?Sized, R: ?Sized, O>(&self,
@@ -534,7 +534,7 @@ pub trait CommunicatorCollectives: Communicator {
     ///
     /// See `examples/immediate_scan.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.12
     fn immediate_exclusive_scan_into<'a, Sc, S: ?Sized, R: ?Sized, O>
@@ -583,7 +583,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/broadcast.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.4
     fn broadcast_into<Buf: ?Sized>(&self, buffer: &mut Buf)
@@ -611,7 +611,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.5
     fn gather_into<S: ?Sized>(&self, sendbuf: &S)
@@ -643,7 +643,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.5
     fn gather_into_root<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -678,7 +678,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.5
     fn gather_varcount_into<S: ?Sized>(&self, sendbuf: &S)
@@ -712,7 +712,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.5
     fn gather_varcount_into_root<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -746,7 +746,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/scatter.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.6
     fn scatter_into<R: ?Sized>(&self, recvbuf: &mut R)
@@ -778,7 +778,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/scatter.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.6
     fn scatter_into_root<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -813,7 +813,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/scatter_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.6
     fn scatter_varcount_into<R: ?Sized>(&self, recvbuf: &mut R)
@@ -847,7 +847,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/scatter_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.6
     fn scatter_varcount_into_root<S: ?Sized, R: ?Sized>(&self, sendbuf: &S, recvbuf: &mut R)
@@ -877,7 +877,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.9.1
     fn reduce_into<S: ?Sized, O>(&self, sendbuf: &S, op: O)
@@ -905,7 +905,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.9.1
     fn reduce_into_root<S: ?Sized, R: ?Sized, O>(&self, sendbuf: &S, recvbuf: &mut R, op: O)
@@ -931,7 +931,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_broadcast.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.2
     fn immediate_broadcast_into<'a, Sc, Buf: ?Sized>(&self,
@@ -961,7 +961,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.3
     fn immediate_gather_into<'a, Sc, S: ?Sized>(&self, scope: Sc, sendbuf: &'a S)
@@ -993,7 +993,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_gather.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.3
     fn immediate_gather_into_root<'a, Sc, S: ?Sized, R: ?Sized>(&self,
@@ -1030,7 +1030,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.3
     fn immediate_gather_varcount_into<'a, Sc, S: ?Sized>(&self,
@@ -1065,7 +1065,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_gather_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.3
     fn immediate_gather_varcount_into_root<'a, Sc, S: ?Sized, R: ?Sized>
@@ -1103,7 +1103,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_scatter.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.4
     fn immediate_scatter_into<'a, Sc, R: ?Sized>(&self,
@@ -1137,7 +1137,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_scatter.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.4
     fn immediate_scatter_into_root<'a, Sc, S: ?Sized, R: ?Sized>
@@ -1175,7 +1175,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_scatter_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.4
     fn immediate_scatter_varcount_into<'a, Sc, R: ?Sized>(&self,
@@ -1210,7 +1210,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_scatter_varcount.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.4
     fn immediate_scatter_varcount_into_root<'a, Sc, S: ?Sized, R: ?Sized>
@@ -1249,7 +1249,7 @@ pub trait Root: AsCommunicator
     ///
     /// See `examples/immediate_reduce.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.7
     fn immediate_reduce_into<'a, Sc, S: ?Sized, O>(&self,
@@ -1285,7 +1285,7 @@ pub trait Root: AsCommunicator
     ///
     /// This function must be called on the root process.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.12.7
     fn immediate_reduce_into_root<'a, Sc, S: ?Sized, R: ?Sized, O>
@@ -1326,7 +1326,7 @@ impl<'a, C: 'a + Communicator> Root for Process<'a, C> {
 pub trait Operation: AsRaw<Raw = MPI_Op> {
     /// Returns whether the operation is commutative.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.9.7
     fn is_commutative(&self) -> bool {
@@ -1345,7 +1345,7 @@ impl<'a, T: 'a + Operation> Operation for &'a T {}
 ///
 /// See `examples/reduce.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 5.9.2
 #[derive(Copy, Clone)]
@@ -1469,7 +1469,7 @@ impl<'a> UserOperation<'a> {
     ///
     /// **Note:** If the closure panics, the entire program will abort.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 5.9.5
     pub fn new<F>(commute: bool, function: F) -> Self
@@ -1538,7 +1538,7 @@ unsafe fn wrapper<F>(function: &F,
 ///
 /// See `examples/reduce.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 5.9.7
 pub fn reduce_local_into<S: ?Sized, R: ?Sized, O>(inbuf: &S, inoutbuf: &mut R, op: O)

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -88,14 +88,14 @@ impl<'a> DatatypeRef<'a> {
 
 /// A system datatype, e.g. `MPI_FLOAT`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.2.2
 pub type SystemDatatype = DatatypeRef<'static>;
 
 /// A direct equivalence exists between the implementing type and an MPI datatype
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.2.2
 pub unsafe trait Equivalence {
@@ -141,7 +141,7 @@ equivalent_system_datatype!(isize, ffi::RSMPI_INT64_T);
 
 /// A user defined MPI datatype
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 4
 pub struct UserDatatype(MPI_Datatype);
@@ -152,7 +152,7 @@ impl UserDatatype {
     /// # Examples
     /// See `examples/contiguous.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn contiguous<D>(count: Count, oldtype: &D) -> UserDatatype
@@ -172,7 +172,7 @@ impl UserDatatype {
     /// # Examples
     /// See `examples/vector.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn vector<D>(count: Count, blocklength: Count, stride: Count, oldtype: &D) -> UserDatatype
@@ -188,7 +188,7 @@ impl UserDatatype {
 
     /// Like `vector()` but `stride` is given in bytes rather than elements of `oldtype`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn heterogeneous_vector<D>(count: Count,
@@ -210,7 +210,7 @@ impl UserDatatype {
     /// Block `i` will be `blocklengths[i]` items of datytpe `oldtype` long and displaced by
     /// `dispplacements[i]` items of the `oldtype`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn indexed<D>(blocklengths: &[Count], displacements: &[Count], oldtype: &D) -> UserDatatype
@@ -233,7 +233,7 @@ impl UserDatatype {
     /// Block `i` will be `blocklengths[i]` items of datytpe `oldtype` long and displaced by
     /// `dispplacements[i]` bytes.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn heterogeneous_indexed<D>(blocklengths: &[Count],
@@ -257,7 +257,7 @@ impl UserDatatype {
 
     /// Construct a new type out of blocks of the same length and individual displacements.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn indexed_block<D>(blocklength: Count,
@@ -281,7 +281,7 @@ impl UserDatatype {
     /// Construct a new type out of blocks of the same length and individual displacements.
     /// Displacements are in bytes.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn heterogeneous_indexed_block<D>(blocklength: Count,
@@ -307,7 +307,7 @@ impl UserDatatype {
     /// # Examples
     /// See `examples/structured.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 4.1.2
     pub fn structured(count: Count, blocklengths: &[Count], displacements: &[Address],
@@ -929,7 +929,7 @@ impl<'b, B: ?Sized, C, D> PartitionedBufferMut for PartitionMut<'b, B, C, D>
 /// # Examples
 /// See `examples/structured.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 4.1.5
 pub fn address_of<T>(x: &T) -> Address {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -86,7 +86,7 @@ impl Drop for Universe {
 /// # Examples
 /// See `examples/init_with_threading.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 12.4.3
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -165,7 +165,7 @@ fn is_initialized() -> bool {
 /// # Examples
 /// See `examples/simple.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 8.7
 pub fn initialize() -> Option<Universe> {
@@ -182,7 +182,7 @@ pub fn initialize() -> Option<Universe> {
 /// # Examples
 /// See `examples/init_with_threading.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 12.4.3
 pub fn initialize_with_threading(threading: Threading) -> Option<(Universe, Threading)> {

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -42,7 +42,7 @@ pub mod traits {
 /// identified process.
 /// - A communicator can also be used as a source via the `AnyProcess` identifier.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.2.3
 pub unsafe trait Source: AsCommunicator {
@@ -58,7 +58,7 @@ pub unsafe trait Source: AsCommunicator {
     /// in a multi-threaded set-up). For a probe operation with stronger guarantees, see
     /// `matched_probe()`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.1
     fn probe_with_tag(&self, tag: Tag) -> Status {
@@ -81,7 +81,7 @@ pub unsafe trait Source: AsCommunicator {
     /// in a multi-threaded set-up). For a probe operation with stronger guarantees, see
     /// `matched_probe()`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.1
     fn probe(&self) -> Status {
@@ -96,7 +96,7 @@ pub unsafe trait Source: AsCommunicator {
     /// incoming message and a `Message` which can and *must* subsequently be used in a
     /// `matched_receive()` to receive the probed message.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.2
     fn matched_probe_with_tag(&self, tag: Tag) -> (Message, Status) {
@@ -120,7 +120,7 @@ pub unsafe trait Source: AsCommunicator {
     /// incoming message and a `Message` which can and *must* subsequently be used in a
     /// `matched_receive()` to receive the probed message.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.2
     fn matched_probe(&self) -> (Message, Status) {
@@ -132,7 +132,7 @@ pub unsafe trait Source: AsCommunicator {
     /// Receive a message from `Source` `&self` tagged `tag` containing a single instance of type
     /// `Msg`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive_with_tag<Msg>(&self, tag: Tag) -> (Msg, Status)
@@ -161,7 +161,7 @@ pub unsafe trait Source: AsCommunicator {
     /// let x = world.any_process().receive::<f64>();
     /// ```
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive<Msg>(&self) -> (Msg, Status)
@@ -174,7 +174,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// Receive a message from `Source` `&self` tagged `tag` into `Buffer` `buf`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive_into_with_tag<Buf: ?Sized>(&self, buf: &mut Buf, tag: Tag) -> Status
@@ -197,7 +197,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// Receive a message from `Source` `&self` into `Buffer` `buf`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive_into<Buf: ?Sized>(&self, buf: &mut Buf) -> Status
@@ -211,7 +211,7 @@ pub unsafe trait Source: AsCommunicator {
     /// Receive a message from `Source` `&self` tagged `tag` containing multiple instances of type
     /// `Msg` into a `Vec`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive_vec_with_tag<Msg>(&self, tag: Tag) -> (Vec<Msg>, Status)
@@ -228,7 +228,7 @@ pub unsafe trait Source: AsCommunicator {
     /// # Examples
     /// See `examples/send_receive.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.4
     fn receive_vec<Msg>(&self) -> (Vec<Msg>, Status)
@@ -241,7 +241,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// Initiate receiving a message matching `tag` into `buf`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_receive_into_with_tag<'a, Sc, Buf: ?Sized>(&self,
@@ -272,7 +272,7 @@ pub unsafe trait Source: AsCommunicator {
     /// # Examples
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_receive_into<'a, Sc, Buf: ?Sized>(&self,
@@ -287,7 +287,7 @@ pub unsafe trait Source: AsCommunicator {
 
     /// Initiate a non-blocking receive operation for messages matching tag `tag`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_receive_with_tag<Msg>(&self, tag: Tag) -> ReceiveFuture<Msg>
@@ -316,7 +316,7 @@ pub unsafe trait Source: AsCommunicator {
     /// # Examples
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_receive<Msg>(&self) -> ReceiveFuture<Msg>
@@ -331,7 +331,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// Like `Probe` but returns a `None` immediately if there is no incoming message to be probed.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.1
     fn immediate_probe_with_tag(&self, tag: Tag) -> Option<Status> {
@@ -357,7 +357,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// Like `Probe` but returns a `None` immediately if there is no incoming message to be probed.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.1
     fn immediate_probe(&self) -> Option<Status> {
@@ -371,7 +371,7 @@ pub unsafe trait Source: AsCommunicator {
     /// Like `MatchedProbe` but returns a `None` immediately if there is no incoming message to be
     /// probed.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.2
     fn immediate_matched_probe_with_tag(&self, tag: Tag) -> Option<(Message, Status)> {
@@ -400,7 +400,7 @@ pub unsafe trait Source: AsCommunicator {
     /// Like `MatchedProbe` but returns a `None` immediately if there is no incoming message to be
     /// probed.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.2
     fn immediate_matched_probe(&self) -> Option<(Message, Status)> {
@@ -427,7 +427,7 @@ unsafe impl<'a, C> Source for Process<'a, C> where C: 'a + Communicator
 /// # Examples
 /// - Using a `Process` as the destination will send data to that specific process.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.2.3
 pub trait Destination: AsCommunicator {
@@ -438,7 +438,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Send the contents of a `Buffer` to the `Destination` `&self` and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.1
     fn send_with_tag<Buf: ?Sized>(&self, buf: &Buf, tag: Tag)
@@ -472,7 +472,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// See also `examples/send_receive.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.2.1
     fn send<Buf: ?Sized>(&self, buf: &Buf)
@@ -485,7 +485,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Send the contents of a `Buffer` to the `Destination` `&self` and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn buffered_send_with_tag<Buf: ?Sized>(&self, buf: &Buf, tag: Tag)
@@ -505,7 +505,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Send the contents of a `Buffer` to the `Destination` `&self`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn buffered_send<Buf: ?Sized>(&self, buf: &Buf)
@@ -520,7 +520,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Completes only once the matching receive operation has started.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn synchronous_send_with_tag<Buf: ?Sized>(&self, buf: &Buf, tag: Tag)
@@ -542,7 +542,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Completes only once the matching receive operation has started.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn synchronous_send<Buf: ?Sized>(&self, buf: &Buf)
@@ -557,7 +557,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Fails if the matching receive operation has not been posted.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn ready_send_with_tag<Buf: ?Sized>(&self, buf: &Buf, tag: Tag)
@@ -579,7 +579,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Fails if the matching receive operation has not been posted.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.4
     fn ready_send<Buf: ?Sized>(&self, buf: &Buf)
@@ -592,7 +592,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in standard mode and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_send_with_tag<'a, Sc, Buf: ?Sized>(&self,
@@ -623,7 +623,7 @@ pub trait Destination: AsCommunicator {
     /// # Examples
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf) -> Request<'a, Sc>
@@ -637,7 +637,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in buffered mode and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_buffered_send_with_tag<'a, Sc, Buf: ?Sized>(&self,
@@ -665,7 +665,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in buffered mode.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_buffered_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf)
@@ -680,7 +680,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in synchronous mode and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_synchronous_send_with_tag<'a, Sc, Buf: ?Sized>(&self,
@@ -708,7 +708,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in synchronous mode.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_synchronous_send<'a, Sc, Buf: ?Sized>(&self,
@@ -725,7 +725,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// Initiate sending the data in `buf` in ready mode and tag it.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_ready_send_with_tag<'a, Sc, Buf: ?Sized>(&self,
@@ -757,7 +757,7 @@ pub trait Destination: AsCommunicator {
     ///
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.2
     fn immediate_ready_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf)
@@ -778,7 +778,7 @@ impl<'a, C> Destination for Process<'a, C> where C: 'a + Communicator
 
 /// Describes the result of a point to point receive operation.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.2.5
 #[derive(Copy, Clone)]
@@ -819,7 +819,7 @@ impl fmt::Debug for Status {
 
 /// Describes a pending incoming message, probed by a `matched_probe()`.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.8.2
 #[must_use]
@@ -835,7 +835,7 @@ impl Message {
     ///
     /// Receives the message `&self` which contains a single instance of type `Msg`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.3
     pub fn matched_receive<Msg>(self) -> (Msg, Status)
@@ -853,7 +853,7 @@ impl Message {
     ///
     /// Receive the message `&self` with contents matching `buf`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.3
     pub fn matched_receive_into<Buf: ?Sized>(mut self, buf: &mut Buf) -> Status
@@ -875,7 +875,7 @@ impl Message {
     ///
     /// Asynchronously receive the message `&self` with contents matching `buf`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.3
     pub fn immediate_matched_receive_into<'a, Sc, Buf: ?Sized + 'a>(mut self,
@@ -920,7 +920,7 @@ impl Drop for Message {
 
 /// Receive a previously probed message containing multiple instances of type `Msg` into a `Vec`.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.8.3
 pub trait MatchedReceiveVec {
@@ -948,7 +948,7 @@ impl MatchedReceiveVec for (Message, Status) {
 /// Sends `msg` to `destination` tagging it `sendtag` and simultaneously receives an
 /// instance of `R` tagged `receivetag` from `source`.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive_with_tags<M, D, R, S>(msg: &M,
@@ -978,7 +978,7 @@ pub fn send_receive_with_tags<M, D, R, S>(msg: &M,
 /// # Examples
 /// See `examples/send_receive.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive<R, M, D, S>(msg: &M, destination: &D, source: &S) -> (R, Status)
@@ -994,7 +994,7 @@ pub fn send_receive<R, M, D, S>(msg: &M, destination: &D, source: &S) -> (R, Sta
 /// simultaneously receives a message tagged `receivetag` from `source` into
 /// `buf`.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive_into_with_tags<M: ?Sized, D, B: ?Sized, S>(msg: &M,
@@ -1033,7 +1033,7 @@ pub fn send_receive_into_with_tags<M: ?Sized, D, B: ?Sized, S>(msg: &M,
 /// simultaneously receives a message from `source` into
 /// `buf`.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive_into<M: ?Sized, D, B: ?Sized, S>(msg: &M,
@@ -1058,7 +1058,7 @@ pub fn send_receive_into<M: ?Sized, D, B: ?Sized, S>(msg: &M,
 /// simultaneously receives a message tagged `receivetag` from `source` and replaces the
 /// contents of `buf` with it.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive_replace_into_with_tags<B: ?Sized, D, S>(buf: &mut B,
@@ -1092,7 +1092,7 @@ pub fn send_receive_replace_into_with_tags<B: ?Sized, D, S>(buf: &mut B,
 /// simultaneously receives a message from `source` and replaces the contents of
 /// `buf` with it.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.10
 pub fn send_receive_replace_into<B: ?Sized, D, S>(buf: &mut B,

--- a/src/request.rs
+++ b/src/request.rs
@@ -57,7 +57,7 @@ fn is_null(request: MPI_Request) -> bool {
 ///
 /// See `examples/immediate.rs`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 3.7.1
 #[must_use]
@@ -136,7 +136,7 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.3
     pub fn wait(self) -> Status {
@@ -149,7 +149,7 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// Will block execution of the calling thread until the associated operation has finished.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.3
     pub fn wait_without_status(self) {
@@ -165,7 +165,7 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.7.3
     pub fn test(self) -> Result<Status, Self> {
@@ -196,7 +196,7 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// See `examples/immediate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 3.8.4
     pub fn cancel(&self) {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -48,7 +48,7 @@ pub type Rank = c_int;
 
 /// A built-in communicator, e.g. `MPI_COMM_WORLD`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.4
 #[derive(Copy, Clone)]
@@ -100,7 +100,7 @@ impl AsCommunicator for SystemCommunicator {
 
 /// A user-defined communicator
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.4
 pub struct UserCommunicator(MPI_Comm);
@@ -183,7 +183,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Examples
     /// See `examples/simple.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.1
     fn size(&self) -> Rank {
@@ -199,7 +199,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Examples
     /// See `examples/simple.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.1
     fn rank(&self) -> Rank {
@@ -241,7 +241,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// See enum `CommunicatorRelation`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.1
     fn compare<C: ?Sized>(&self, other: &C) -> CommunicatorRelation
@@ -260,7 +260,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// See `examples/duplicate.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn duplicate(&self) -> UserCommunicator {
@@ -281,7 +281,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// See `examples/split.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn split_by_color(&self, color: Color) -> Option<UserCommunicator> {
@@ -293,7 +293,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// Like `split()` but orders processes according to the value of `key` in the new
     /// communicators.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn split_by_color_with_key(&self, color: Color, key: Key) -> Option<UserCommunicator> {
@@ -319,7 +319,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// See `examples/split.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn split_by_subgroup_collective<G: ?Sized>(&self, group: &G) -> Option<UserCommunicator>
@@ -340,7 +340,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// See `examples/split.rs`
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn split_by_subgroup<G: ?Sized>(&self, group: &G) -> Option<UserCommunicator>
@@ -354,7 +354,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// Like `split_by_subgroup()` but can avoid collision of concurrent calls
     /// (i.e. multithreaded) by passing in distinct tags.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.4.2
     fn split_by_subgroup_with_tag<G: ?Sized>(&self, group: &G, tag: Tag) -> Option<UserCommunicator>
@@ -369,7 +369,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
 
     /// The group associated with this communicator
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn group(&self) -> UserGroup {
@@ -382,7 +382,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
 
     /// Abort program execution
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 8.7
     fn abort(&self, errorcode: c_int) -> ! {
@@ -395,7 +395,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
 
 /// The relation between two communicators.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.4.1
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -479,7 +479,7 @@ impl<'a, C> AsCommunicator for AnyProcess<'a, C> where C: 'a + Communicator
 
 /// A built-in group, e.g. `MPI_GROUP_EMPTY`
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.2.1
 #[derive(Copy, Clone)]
@@ -503,7 +503,7 @@ impl Group for SystemGroup {}
 
 /// A user-defined group of processes
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.2.1
 pub struct UserGroup(MPI_Group);
@@ -533,7 +533,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// Constructs a new group that contains all members of the first group followed by all members
     /// of the second group that are not also members of the first group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn union<G>(&self, other: &G) -> UserGroup
@@ -551,7 +551,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// Constructs a new group that contains all processes that are members of both the first and
     /// second group in the order they have in the first group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn intersection<G>(&self, other: &G) -> UserGroup
@@ -569,7 +569,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// Constructs a new group that contains all members of the first group that are not also
     /// members of the second group in the order they have in the first group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn difference<G>(&self, other: &G) -> UserGroup
@@ -587,7 +587,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// Constructs a new group where the process with rank `ranks[i]` in the old group has rank `i`
     /// in the new group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn include(&self, ranks: &[Rank]) -> UserGroup {
@@ -603,7 +603,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// Constructs a new group containing those processes from the old group that are not mentioned
     /// in `ranks`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.2
     fn exclude(&self, ranks: &[Rank]) -> UserGroup {
@@ -616,7 +616,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
 
     /// Number of processes in the group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.1
     fn size(&self) -> Rank {
@@ -629,7 +629,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
 
     /// Rank of this process within the group.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.1
     fn rank(&self) -> Option<Rank> {
@@ -648,7 +648,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     ///
     /// If the process is not a member of the other group, returns `None`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.1
     fn translate_rank<G>(&self, rank: Rank, other: &G) -> Option<Rank>
@@ -669,7 +669,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     ///
     /// If a process is not a member of the other group, returns `None`.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.1
     fn translate_ranks<G>(&self, ranks: &[Rank], other: &G) -> Vec<Option<Rank>>
@@ -680,7 +680,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
 
     /// Compare two groups.
     ///
-    /// # Standard section(s)
+    /// # MPI standard section(s)
     ///
     /// 6.3.1
     fn compare<G>(&self, other: &G) -> GroupRelation
@@ -696,7 +696,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
 
 /// The relation between two groups.
 ///
-/// # Standard section(s)
+/// # MPI standard section(s)
 ///
 /// 6.3.1
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
This was not clear to me, while reading the docs, TBH.
I'd ideally keep it as:
```
    /// # MPI standard reference
    /// Section 6.8, see the `MPI_Comm_set_name` function
```
but it's not trivial to automate.