### PR TITLE
Add RSMPI_C_BOOL as the equivalent_system_datatype for bool

### DIFF
--- a/examples/all_gather_bool.rs
+++ b/examples/all_gather_bool.rs
@@ -1,0 +1,19 @@
+#![deny(warnings)]
+extern crate mpi;
+
+use mpi::traits::*;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let rank = world.rank();
+    let count = world.size() as usize;
+
+    let mut a = vec![false; count];
+    world.all_gather_into(&(rank % 2 == 0), &mut a[..]);
+
+    let answer: Vec<_> = (0..count).map(|i| i % 2 == 0).collect();
+
+    assert_eq!(answer, a);
+}

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -119,6 +119,8 @@ macro_rules! equivalent_system_datatype {
     )
 }
 
+equivalent_system_datatype!(bool, ffi::RSMPI_C_BOOL);
+
 equivalent_system_datatype!(f32, ffi::RSMPI_FLOAT);
 equivalent_system_datatype!(f64, ffi::RSMPI_DOUBLE);
 

--- a/src/ffi/rsmpi.c
+++ b/src/ffi/rsmpi.c
@@ -1,5 +1,7 @@
 #include "rsmpi.h"
 
+const MPI_Datatype RSMPI_C_BOOL = MPI_C_BOOL;
+
 const MPI_Datatype RSMPI_FLOAT = MPI_FLOAT;
 const MPI_Datatype RSMPI_DOUBLE = MPI_DOUBLE;
 

--- a/src/ffi/rsmpi.h
+++ b/src/ffi/rsmpi.h
@@ -2,6 +2,8 @@
 #define RSMPI_INCLUDED
 #include "mpi.h"
 
+extern const MPI_Datatype RSMPI_C_BOOL;
+
 extern const MPI_Datatype RSMPI_FLOAT;
 extern const MPI_Datatype RSMPI_DOUBLE;
 


### PR DESCRIPTION
Since the Rust team [committed to](https://github.com/rust-lang/rust/pull/46176#issuecomment-359593446) ABI compatibility between Rust's `bool` and C's `_Bool`, I've added a mapping from bool to ffi::RSMPI_C_BOOL.

Addresses issue #34.