### PR TITLE
Export stable ABI for c2f

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
     fi
 
 script:
-  - cargo build -v && cargo test -v && sh ci/run-examples.sh
+  - cargo build -v && cargo test --all -v && sh ci/run-examples.sh
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo clippy -v;
     fi

--- a/mpi-sys/src/lib.rs
+++ b/mpi-sys/src/lib.rs
@@ -7,3 +7,126 @@
 #![cfg_attr(feature="cargo-clippy", allow(expl_impl_clone_on_copy))]
 #![cfg_attr(feature="cargo-clippy", allow(unreadable_literal))]
 include!(concat!(env!("OUT_DIR"), "/functions_and_types.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    #[test]
+    fn mpi_fint_compiles() {
+        if false {
+            let _: RSMPI_Fint = unsafe { mem::uninitialized() };
+        }
+    }
+
+    #[test]
+    fn mpi_fint_comm_compiles() {
+        if false {
+            unsafe {
+                let comm: MPI_Comm = mem::uninitialized();
+                let fcomm: RSMPI_Fint = RSMPI_Comm_c2f(comm);
+                let _: MPI_Comm = RSMPI_Comm_f2c(fcomm);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_errhandler_compiles() {
+        if false {
+            unsafe {
+                let errhandler: MPI_Errhandler = mem::uninitialized();
+                let ferrhandler: RSMPI_Fint = RSMPI_Errhandler_c2f(errhandler);
+                let _: MPI_Errhandler = RSMPI_Errhandler_f2c(ferrhandler);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_file_compiles() {
+        if false {
+            unsafe {
+                let file: MPI_File = mem::uninitialized();
+                let ffile: RSMPI_Fint = RSMPI_File_c2f(file);
+                let _: MPI_File = RSMPI_File_f2c(ffile);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_group_compiles() {
+        if false {
+            unsafe {
+                let group: MPI_Group = mem::uninitialized();
+                let fgroup: RSMPI_Fint = RSMPI_Group_c2f(group);
+                let _: MPI_Group = RSMPI_Group_f2c(fgroup);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_info_compiles() {
+        if false {
+            unsafe {
+                let info: MPI_Info = mem::uninitialized();
+                let finfo: RSMPI_Fint = RSMPI_Info_c2f(info);
+                let _: MPI_Info = RSMPI_Info_f2c(finfo);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_message_compiles() {
+        if false {
+            unsafe {
+                let message: MPI_Message = mem::uninitialized();
+                let fmessage: RSMPI_Fint = RSMPI_Message_c2f(message);
+                let _: MPI_Message = RSMPI_Message_f2c(fmessage);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_op_compiles() {
+        if false {
+            unsafe {
+                let op: MPI_Op = mem::uninitialized();
+                let fop: RSMPI_Fint = RSMPI_Op_c2f(op);
+                let _: MPI_Op = RSMPI_Op_f2c(fop);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_request_compiles() {
+        if false {
+            unsafe {
+                let request: MPI_Request = mem::uninitialized();
+                let frequest: RSMPI_Fint = RSMPI_Request_c2f(request);
+                let _: MPI_Request = RSMPI_Request_f2c(frequest);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_datatype_compiles() {
+        if false {
+            unsafe {
+                let datatype: MPI_Datatype = mem::uninitialized();
+                let fdatatype: RSMPI_Fint = RSMPI_Type_c2f(datatype);
+                let _: MPI_Datatype = RSMPI_Type_f2c(fdatatype);
+            }
+        }
+    }
+
+    #[test]
+    fn mpi_fint_win_compiles() {
+        if false {
+            unsafe {
+                let win: MPI_Win = mem::uninitialized();
+                let fwin: RSMPI_Fint = RSMPI_Win_c2f(win);
+                let _: MPI_Win = RSMPI_Win_f2c(fwin);
+            }
+        }
+    }
+}

--- a/mpi-sys/src/rsmpi.c
+++ b/mpi-sys/src/rsmpi.c
@@ -71,3 +71,25 @@ double RSMPI_Wtime() {
 double RSMPI_Wtick() {
   return MPI_Wtick();
 }
+
+#define RSMPI_c2f_def_base(type, ctype, argname) \
+  MPI_Fint RS ## type ## _c2f(ctype     argname) { \
+    return type ## _c2f(argname); \
+  } \
+  \
+  ctype     RS ## type ## _f2c(MPI_Fint argname) { \
+    return type ## _f2c(argname); \
+  }
+
+#define RSMPI_c2f_def(type, argname) RSMPI_c2f_def_base(type, type, argname)
+
+RSMPI_c2f_def(MPI_Comm, comm);
+RSMPI_c2f_def(MPI_Errhandler, errhandler);
+RSMPI_c2f_def(MPI_File, file);
+RSMPI_c2f_def(MPI_Group, group);
+RSMPI_c2f_def(MPI_Info, info);
+RSMPI_c2f_def(MPI_Message, message);
+RSMPI_c2f_def(MPI_Op, op);
+RSMPI_c2f_def(MPI_Request, request);
+RSMPI_c2f_def_base(MPI_Type, MPI_Datatype, datatype);
+RSMPI_c2f_def(MPI_Win, win);

--- a/mpi-sys/src/rsmpi.h
+++ b/mpi-sys/src/rsmpi.h
@@ -2,6 +2,10 @@
 #define RSMPI_INCLUDED
 #include "mpi.h"
 
+// OpenMPI uses the preprocessor to define MPI_Fint - explicitly typedef it
+// here.
+typedef MPI_Fint RSMPI_Fint;
+
 extern const MPI_Datatype RSMPI_C_BOOL;
 
 extern const MPI_Datatype RSMPI_FLOAT;
@@ -68,4 +72,23 @@ extern const MPI_Op RSMPI_BXOR;
 
 double RSMPI_Wtime();
 double RSMPI_Wtick();
+
+// MPICH uses macros for c2f - explicitly define them.
+#define RSMPI_c2f_decl_base(type, ctype, argname) \
+  MPI_Fint RS ## type ## _c2f(ctype     argname); \
+  ctype     RS ## type ## _f2c(MPI_Fint argname)
+
+#define RSMPI_c2f_decl(type, argname) RSMPI_c2f_decl_base(type, type, argname)
+
+RSMPI_c2f_decl(MPI_Comm, comm);
+RSMPI_c2f_decl(MPI_Errhandler, errhandler);
+RSMPI_c2f_decl(MPI_File, file);
+RSMPI_c2f_decl(MPI_Group, group);
+RSMPI_c2f_decl(MPI_Info, info);
+RSMPI_c2f_decl(MPI_Message, message);
+RSMPI_c2f_decl(MPI_Op, op);
+RSMPI_c2f_decl(MPI_Request, request);
+RSMPI_c2f_decl_base(MPI_Type, MPI_Datatype, datatype);
+RSMPI_c2f_decl(MPI_Win, win);
+
 #endif


### PR DESCRIPTION
OpenMPI does not have a typedef for MPI_Fint - added RSMPI_Fint.
MPICH uses macros for c2f - Export a C ABI for these routines (e.g. RSMPI_Comm_c2f).

Addresses #39 .