### PR TITLE
Support for MS-MPI and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An implementation of the C language interface that conforms to MPI-3.1. `rsmpi` 
 
 - [OpenMPI][OpenMPI] 2.0.4, 2.1.2, 3.0.0
 - [MPICH][MPICH] 3.2.1, 3.1.4
+- [MS-MPI (Windows)][MS-MPI] 9.0.1
 
 For a reasonable chance of success with `rsmpi` any MPI implementation that you want to use with it should satisfy the following assumptions that `rsmpi` currently makes:
 
@@ -43,6 +44,7 @@ Furthermore, `rsmpi` uses the `libffi` crate which installs the native `libffi` 
 
 [OpenMPI]: https://www.open-mpi.org
 [MPICH]: https://www.mpich.org
+[MS-MPI]: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
 [rsmpih]: https://github.com/bsteinb/rsmpi/blob/master/src/ffi/rsmpi.h
 [rsmpic]: https://github.com/bsteinb/rsmpi/blob/master/src/ffi/rsmpi.c
 [buildrs]: https://github.com/bsteinb/rsmpi/blob/master/build.rs

--- a/build-probe-mpi/Cargo.toml
+++ b/build-probe-mpi/Cargo.toml
@@ -12,4 +12,6 @@ categories = [ "development-tools::build-utils" ]
 license = "MIT/Apache-2.0"
 
 [dependencies]
+
+[target.'cfg(unix)'.dependencies]
 pkg-config = "0.3"

--- a/build-probe-mpi/src/os/mod.rs
+++ b/build-probe-mpi/src/os/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(windows)]
+pub use self::windows::probe;
+
+#[cfg(unix)]
+pub use self::unix::probe;

--- a/build-probe-mpi/src/os/unix.rs
+++ b/build-probe-mpi/src/os/unix.rs
@@ -1,0 +1,99 @@
+#![deny(missing_docs)]
+#![warn(missing_copy_implementations)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unused_extern_crates)]
+#![warn(unused_import_braces)]
+#![warn(unused_qualifications)]
+
+extern crate pkg_config;
+
+use std::{self, env, error::Error, path::PathBuf, process::Command};
+
+use super::super::Library;
+
+use pkg_config::Config;
+
+impl From<pkg_config::Library> for Library {
+    fn from(lib: pkg_config::Library) -> Self {
+        Library {
+            libs: lib.libs,
+            lib_paths: lib.link_paths,
+            include_paths: lib.include_paths,
+            version: lib.version,
+            _priv: (),
+        }
+    }
+}
+
+fn probe_via_mpicc(mpicc: &str) -> std::io::Result<Library> {
+    // Capture the output of `mpicc -show`. This usually gives the actual compiler command line
+    // invoked by the `mpicc` compiler wrapper.
+    Command::new(mpicc).arg("-show").output().map(|cmd| {
+        let output = String::from_utf8(cmd.stdout).expect("mpicc output is not valid UTF-8");
+        // Collect the libraries that an MPI C program should be linked to...
+        let libs = collect_args_with_prefix(output.as_ref(), "-l");
+        // ... and the library search directories...
+        let libdirs = collect_args_with_prefix(output.as_ref(), "-L")
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
+        // ... and the header search directories.
+        let headerdirs = collect_args_with_prefix(output.as_ref(), "-I")
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
+
+        Library {
+            libs,
+            lib_paths: libdirs,
+            include_paths: headerdirs,
+            version: String::from("unknown"),
+            _priv: (),
+        }
+    })
+}
+
+/// splits a command line by space and collects all arguments that start with `prefix`
+fn collect_args_with_prefix(cmd: &str, prefix: &str) -> Vec<String> {
+    cmd.split_whitespace()
+        .filter_map(|arg| {
+            if arg.starts_with(prefix) {
+                Some(arg[2..].to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Probe the environment for an installed MPI library
+pub fn probe() -> Result<Library, Vec<Box<Error>>> {
+    let mut errs = vec![];
+
+    match probe_via_mpicc(&env::var("MPICC").unwrap_or_else(|_| String::from("mpicc"))) {
+        Ok(lib) => return Ok(lib),
+        Err(err) => {
+            let err: Box<Error> = Box::new(err);
+            errs.push(err)
+        }
+    }
+
+    match Config::new().cargo_metadata(false).probe("mpich") {
+        Ok(lib) => return Ok(Library::from(lib)),
+        Err(err) => {
+            let err: Box<Error> = Box::new(err);
+            errs.push(err)
+        }
+    }
+
+    match Config::new().cargo_metadata(false).probe("openmpi") {
+        Ok(lib) => return Ok(Library::from(lib)),
+        Err(err) => {
+            let err: Box<Error> = Box::new(err);
+            errs.push(err)
+        }
+    }
+
+    Err(errs)
+}

--- a/build-probe-mpi/src/os/windows.rs
+++ b/build-probe-mpi/src/os/windows.rs
@@ -1,0 +1,53 @@
+#![deny(missing_docs)]
+#![warn(missing_copy_implementations)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unused_extern_crates)]
+#![warn(unused_import_braces)]
+#![warn(unused_qualifications)]
+
+use super::super::Library;
+use std::{env, error::Error, path::PathBuf};
+
+/// Probe the environment for MS-MPI
+pub fn probe() -> Result<Library, Vec<Box<Error>>> {
+    let mut errs = vec![];
+
+    let include_path = match env::var("MSMPI_INC") {
+        Ok(include_path) => Some(include_path),
+        Err(err) => {
+            let err: Box<Error> = Box::new(err);
+            errs.push(err);
+            None
+        }
+    };
+
+    let lib_env = if cfg!(target_arch = "i686") {
+        "MSMPI_LIB32"
+    } else if cfg!(target_arch = "x86_64") {
+        "MSMPI_LIB64"
+    } else {
+        panic!("rsmpi does not support your windows architecture!");
+    };
+
+    let lib_path = match env::var(lib_env) {
+        Ok(lib_path) => Some(lib_path),
+        Err(err) => {
+            let err: Box<Error> = Box::new(err);
+            errs.push(err);
+            None
+        }
+    };
+
+    if errs.len() > 0 {
+        return Err(errs);
+    }
+
+    Ok(Library {
+        libs: vec!["msmpi".to_owned()],
+        lib_paths: vec![lib_path.map(PathBuf::from).unwrap()],
+        include_paths: vec![include_path.map(PathBuf::from).unwrap()],
+        version: String::from("unknown"),
+        _priv: (),
+    })
+}

--- a/build.rs
+++ b/build.rs
@@ -6,4 +6,9 @@ fn main() {
     if rustc_version::version().unwrap() >= RustcVersion::parse("1.13.0").unwrap() {
         println!("cargo:rustc-cfg=extern_statics_are_unsafe");
     }
+
+    if cfg!(windows) {
+        // Adds a cfg to identify MS-MPI. This should perhaps be a more robust check in the future.
+        println!("cargo:rustc-cfg=msmpi");
+    }
 }

--- a/examples/split.rs
+++ b/examples/split.rs
@@ -1,8 +1,8 @@
 #![deny(warnings)]
 extern crate mpi;
 
-use mpi::traits::*;
 use mpi::topology::{Color, GroupRelation, SystemGroup};
+use mpi::traits::*;
 
 fn main() {
     let universe = mpi::initialize().unwrap();
@@ -46,17 +46,20 @@ fn main() {
         assert!(odd_comm.is_none());
     }
 
-    if even_group.rank().is_some() {
-        let even_comm = world.split_by_subgroup(&even_group);
-        assert!(even_comm.is_some());
-        let even_comm = even_comm.unwrap();
-        assert_eq!(
-            GroupRelation::Identical,
-            even_comm.group().compare(&even_group)
-        );
+    #[cfg(not(msmpi))]
+    {
+        if even_group.rank().is_some() {
+            let even_comm = world.split_by_subgroup(&even_group);
+            assert!(even_comm.is_some());
+            let even_comm = even_comm.unwrap();
+            assert_eq!(
+                GroupRelation::Identical,
+                even_comm.group().compare(&even_group)
+            );
 
-        let no_comm = world.split_by_subgroup(&odd_group);
-        assert!(no_comm.is_none());
+            let no_comm = world.split_by_subgroup(&odd_group);
+            assert!(no_comm.is_none());
+        }
     }
 
     let oddness_comm = world.split_by_color(Color::with_value(world.rank() % 2));

--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -16,6 +16,6 @@ license = "MIT/Apache-2.0"
 [dependencies]
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.25"
 bindgen = "0.31.3"
 build-probe-mpi = { path = "../build-probe-mpi", version = "0.1" }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -19,10 +19,11 @@
 //! - **6.8**: Naming objects
 //! - **7**: Process topologies
 //! - **Parts of sections**: 8, 10, 12
-use std::{mem, process};
-use std::os::raw::{c_int, c_char};
 use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::{mem, process};
 
+#[cfg(not(msmpi))]
 use super::Tag;
 use ffi;
 use ffi::{MPI_Comm, MPI_Group};
@@ -349,6 +350,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Standard section(s)
     ///
     /// 6.4.2
+    #[cfg(not(msmpi))]
     fn split_by_subgroup<G: ?Sized>(&self, group: &G) -> Option<UserCommunicator>
     where
         G: Group,
@@ -364,6 +366,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Standard section(s)
     ///
     /// 6.4.2
+    #[cfg(not(msmpi))]
     fn split_by_subgroup_with_tag<G: ?Sized>(&self, group: &G, tag: Tag) -> Option<UserCommunicator>
     where
         G: Group,


### PR DESCRIPTION
This commit adds support for the MS-MPI implementation, primarily targeting Windows. I add some code to discover for MS-MPI that only run on Windows, and moved the other MPI probing to a separate probe function for Unix.

I inject an msmpi cfg into both mpi-sys and rsmpi. This may be useful to either surface msmpi specifically functionality or, like I do in this commit, to disable certain features that are missing from MS-MPI.

I noticed two issues when building with the MS-MPI headers:
1. MPI_Comm_create_group was missing.
2. Bindgen does not seem to pick up the MPI_User_function definition

For both of these issues, I just removed the APIs that called these functions when using MS-MPI. This may not be the best method.

I also disabled portions of any tests that rely on these functionalities.

I recommend building without default features on Windows since libffi is not available by default.

I also swapped the gcc crate with cc, as that seems to be the stable version of gcc.