### PR TITLE
Enhancements to mpi::datatype

### DIFF
--- a/examples/complex_datatype.rs
+++ b/examples/complex_datatype.rs
@@ -1,0 +1,80 @@
+#![deny(warnings)]
+extern crate mpi;
+
+use mpi::{
+    datatype::{UncommittedUserDatatype, UserDatatype},
+    traits::*,
+    Address,
+};
+
+macro_rules! offset_of {
+    ($T:ty, $field:tt) => {{
+        let value: $T = unsafe { ::std::mem::uninitialized() };
+
+        let value_loc = &value as *const _ as usize;
+        let field_loc = &value.$field as *const _ as usize;
+
+        ::std::mem::forget(value);
+
+        field_loc - value_loc
+    }};
+}
+
+type TupleType = ([f32; 2], u8);
+
+#[derive(Default)]
+struct ComplexDatatype {
+    b: bool,
+    ints: [i32; 4],
+    tuple: TupleType,
+}
+
+unsafe impl Equivalence for ComplexDatatype {
+    type Out = UserDatatype;
+    fn equivalent_datatype() -> Self::Out {
+        UserDatatype::structured(
+            &[1, 1, 1],
+            &[
+                offset_of!(ComplexDatatype, b) as Address,
+                offset_of!(ComplexDatatype, ints) as Address,
+                offset_of!(ComplexDatatype, tuple) as Address,
+            ],
+            &[
+                bool::equivalent_datatype().into(),
+                UncommittedUserDatatype::contiguous(4, &i32::equivalent_datatype()).as_ref(),
+                UncommittedUserDatatype::structured(
+                    &[2, 1],
+                    &[
+                        offset_of!(TupleType, 0) as Address,
+                        offset_of!(TupleType, 1) as Address,
+                    ],
+                    &[f32::equivalent_datatype(), u8::equivalent_datatype()],
+                ).as_ref(),
+            ],
+        )
+    }
+}
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let root_process = world.process_at_rank(0);
+
+    let mut data = if world.rank() == 0 {
+        ComplexDatatype {
+            b: true,
+            ints: [1, -2, 3, -4],
+            tuple: ([-0.1, 0.1], 7),
+        }
+    } else {
+        ComplexDatatype::default()
+    };
+
+    root_process.broadcast_into(&mut data);
+
+    assert_eq!(true, data.b);
+    assert_eq!([1, -2, 3, -4], data.ints);
+    assert_eq!([-0.1, 0.1], data.tuple.0);
+    assert_eq!(7, data.tuple.1);
+}

--- a/examples/datatype_dup.rs
+++ b/examples/datatype_dup.rs
@@ -1,0 +1,27 @@
+#![deny(warnings)]
+extern crate mpi;
+
+use mpi::datatype::DynBufferMut;
+use mpi::traits::*;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let root_process = world.process_at_rank(0);
+
+    let int_type = i32::equivalent_datatype().dup();
+
+    let mut ints = if world.rank() == 0 {
+        [1i32, 2, 3, 4]
+    } else {
+        [0, 0, 0, 0]
+    };
+
+    let mut buffer =
+        unsafe { DynBufferMut::from_raw(ints.as_mut_ptr(), ints.count(), int_type.as_ref()) };
+
+    root_process.broadcast_into(&mut buffer);
+
+    assert_eq!([1, 2, 3, 4], ints);
+}

--- a/examples/structured.rs
+++ b/examples/structured.rs
@@ -9,12 +9,14 @@ struct MyInts([i32; 3]);
 unsafe impl Equivalence for MyInts {
     type Out = UserDatatype;
     fn equivalent_datatype() -> Self::Out {
-        
-        let int_datatype = i32::equivalent_datatype();
-        mpi::datatype::UserDatatype::structured(
+        UserDatatype::structured(
             &[1, 1, 1],
-            &[(size_of::<i32>() * 2) as mpi::Address, size_of::<i32>() as mpi::Address, 0],
-            &[&int_datatype, &int_datatype, &int_datatype],
+            &[
+                (size_of::<i32>() * 2) as mpi::Address,
+                size_of::<i32>() as mpi::Address,
+                0,
+            ],
+            &[i32::equivalent_datatype(); 3],
         )
     }
 }
@@ -31,8 +33,6 @@ fn main() {
         let mut ints: [i32; 3] = [0, 0, 0];
         root_process.broadcast_into(&mut ints[..]);
 
-        assert_eq!(1, ints[0]);
-        assert_eq!(2, ints[1]);
-        assert_eq!(3, ints[2]);
+        assert_eq!([1, 2, 3], ints);
     }
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,5 +1,3 @@
-//! Describing data
-//!
 //! The core function of MPI is getting data from point A to point B (where A and B are e.g. single
 //! processes, multiple processes, the filesystem, ...). It offers facilities to describe that data
 //! (layout in memory, behavior under certain operators) that go beyound a start address and a
@@ -14,6 +12,35 @@
 //! an object in memory like all elements below the diagonal of a dense matrix stored in row-major
 //! order.
 //!
+//! ## Derived Datatypes
+//! Derived MPI datatypes can exist in either an "uncommitted" or "committed" state. Only
+//! "committed" datatypes can be used in MPI communication. There is a cost to committing a
+//! datatype: only a final aggregate type should be committed when building it from component
+//! derived datatypes.
+//!
+//! In order to represent the difference between committed and uncommitted `MPI_Datatype` objects,
+//! two different flavors of types representing the "committed"-ness of the type are exposed.
+//! Orthogonally, there are types representing both "owned" `MPI_Datatype` objects and "borrowed"
+//! `MPI_Datatype` objects. This means there are four different types for `MPI_Datatype`:
+//! - `UserDatatype` represents a committed, owned `MPI_Datatype`
+//! - `DatatypeRef<'_>` represents a committed, borrowed `MPI_Datatype`.
+//!   - All builtin types are `DatatypeRef<'static>`
+//! - `UncommittedUserDatatype` represents an uncommitted, owned `MPI_Datatype`
+//! - `UncommittedDatatypeRef<'_>` represents an uncommitted, borrowed `MPI_Datatype`
+//!
+//! Along with this, there are two traits that are applied to these types:
+//! - `UncommittedDatatype` indicates the type represents a possibly uncommitted `MPI_Datatype`
+//! - `Datatype` indicates the type represents a committed `MPI_Datatype`
+//!
+//! An important concept here is that all committed `Datatype` objects are also
+//! `UncommittedDatatype` objects. This may seem unintuitive at first, but as far as MPI is
+//! concerned, "committing" a datatype is purely a promotion, enabling more capabilities. This
+//! allows `Datatype` and `UncommittedDatatype` objects to be used interchangeably in the same
+//! `Datatype` constructors.
+//!
+//! For more information on derived datatypes, see section 4.1 of the MPI 3.1 Standard.
+//!
+//! ## Data Buffers
 //! A `Buffer` describes a specific piece of data in memory that MPI should operate on. In addition
 //! to specifying the datatype of the data. It knows the address in memory where the data begins
 //! and how many instances of the datatype are contained in the data. The `Buffer` trait is

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -664,7 +664,7 @@ impl<'a> From<&'a UncommittedUserDatatype> for UncommittedDatatypeRef<'a> {
 ///
 /// `Datatype` always represents a committed datatype that can be immediately used for sending and
 /// receiving messages. `UncommittedDatatype` is used for datatypes that are possibly uncommitted.
-pub trait Datatype: AsRaw<Raw = MPI_Datatype> {}
+pub trait Datatype: UncommittedDatatype {}
 impl<'a, D> Datatype for &'a D where D: 'a + Datatype {}
 
 /// An UncommittedDatatype is a partial description of the layout of messages in memory which may

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -661,6 +661,9 @@ impl<'a> From<&'a UncommittedUserDatatype> for UncommittedDatatypeRef<'a> {
 }
 
 /// A Datatype describes the layout of messages in memory.
+///
+/// `Datatype` always represents a committed datatype that can be immediately used for sending and
+/// receiving messages. `UncommittedDatatype` is used for datatypes that are possibly uncommitted.
 pub trait Datatype: AsRaw<Raw = MPI_Datatype> {}
 impl<'a, D> Datatype for &'a D where D: 'a + Datatype {}
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,7 +2,7 @@
 
 /// Rust C bridge traits
 pub mod traits {
-    pub use super::{AsRaw, AsRawMut};
+    pub use super::{AsRaw, AsRawMut, FromRaw, MatchesRaw};
 }
 
 /// A rust type than can identify as a raw value understood by the MPI C API.
@@ -28,3 +28,14 @@ pub unsafe trait AsRawMut: AsRaw {
     /// A mutable pointer to the raw value
     fn as_raw_mut(&mut self) -> *mut <Self as AsRaw>::Raw;
 }
+
+/// Conversion for the Rust type from the raw MPI handle type.
+pub trait FromRaw: AsRaw {
+    /// Constructs the Rust type, with all its semantics, from the raw MPI type.
+    unsafe fn from_raw(handle: <Self as AsRaw>::Raw) -> Self;
+}
+
+/// A marker trait that indicates the Rust type is exactly equivalent in representation to the Raw
+/// type, allowing slices of the type to be used with MPI APIs that accept arrays of its Raw MPI
+/// handle.
+pub unsafe trait MatchesRaw: AsRaw {}


### PR DESCRIPTION
- Adds new types: `UncommittedUserDatatype` + `UncommittedDatatypeRef`
  - same constructors as `UserDatatype` and `DatatypeRef`
  - `UncommittedUserDatatype::commit` consumes the old value to produce a `UserDatatype`
  - `UserDatatype::structured` and `UncommittedUserDatatype::structured` constructors takes a slice that can be passed directly to underlying `MPI_Type_create_struct` call without copy
  - new `as_ref()` functions for `UserDatatype` and `UncommittedUserDatatype`
- Adds `UncommittedDatatype` trait
  - Implemented for all Datatype types
  - Supports capability for duplicating the datatype
- `From` implemented for Datatype types to allow downcasting of heterogeneous types when being mixed into a single contiguous array. Utility demonstrated by `bool::equivalent_datatype().into()` in `complex_datatype.rs`.
- New generic trait: `FromRaw`
  - Provides fixed way for constructing an `mpi::Foo` from a `MPI_Foo`
  - Implemented for all the Datatype types
- New generic trait: `MatchesRaw`
  - Marker trait that indicates it's representationally safe to treat a slice of `Foo` as a slice of `Foo::Raw`
  - Implemented for all of the Datatype types
- Adds a `complex_datatype.rs` test that constructs a `UserDatatype` from multiple `UncommittedUserDatatype` values