### PR TITLE
Add Appveyor CI using MS-MPI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+image: Visual Studio 2017
+
+install:
+  - ps: ci\windows\install.ps1
+
+build_script:
+  - ps: ci\windows\build.ps1
+
+test_script:
+  - ps: ci\windows\test.ps1

--- a/ci/windows/build.ps1
+++ b/ci/windows/build.ps1
@@ -1,0 +1,11 @@
+$env:MSMPI_BIN = "C:\Program Files\Microsoft MPI\Bin\"
+$env:MSMPI_INC = "C:\Program Files (x86)\Microsoft SDKs\MPI\Include\"
+$env:MSMPI_LIB32 = "C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\"
+$env:MSMPI_LIB64 = "C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\"
+
+$env:PATH += ";$HOME\.cargo\bin;$env:MSMPI_BIN"
+
+cmd.exe /c "cargo build --no-default-features --all --examples 2>&1"
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/ci/windows/install.ps1
+++ b/ci/windows/install.ps1
@@ -1,0 +1,48 @@
+Write-Output "Installing MS-MPI SDK..."
+
+Invoke-WebRequest `
+    -Uri https://download.microsoft.com/download/4/A/6/4A6AAED8-200C-457C-AB86-37505DE4C90D/msmpisdk.msi `
+    -OutFile .\msmpisdk.msi
+
+
+Start-Process -Wait -FilePath msiexec.exe -ArgumentList "/i msmpisdk.msi /quiet /qn /log install.log"
+# For some reason we're getting a bad exit code even on success
+# if ($LASTEXITCODE -ne 0) {
+#     exit $LASTEXITCODE
+# }
+
+Write-Output "Installed MS-MPI SDK!"
+
+Write-Output "Installing MS-MPI Redist..."
+
+Invoke-WebRequest `
+    -Uri https://download.microsoft.com/download/4/A/6/4A6AAED8-200C-457C-AB86-37505DE4C90D/msmpisetup.exe `
+    -OutFile .\msmpisetup.exe
+
+Start-Process -Wait -FilePath msmpisetup.exe -ArgumentList "-unattend -full"
+    
+Write-Output "Installed MS-MPI Redist!"
+
+Write-Output "Installing Rust..."
+
+Invoke-WebRequest `
+    -Uri https://win.rustup.rs/ `
+    -OutFile rustup-init.exe
+
+cmd.exe /c ".\rustup-init.exe -y 2>&1"
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+Write-Output "Installed Rust!"
+
+$env:PATH += ";$HOME\.cargo\bin"
+
+Write-Output "Installing cargo-mpirun..."
+
+cmd.exe /c "cargo install --force cargo-mpirun 2>&1"
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+Write-Output "Installed cargo-mpirun!"

--- a/ci/windows/test.ps1
+++ b/ci/windows/test.ps1
@@ -1,0 +1,48 @@
+$env:MSMPI_BIN = "C:\Program Files\Microsoft MPI\Bin\"
+$env:MSMPI_INC = "C:\Program Files (x86)\Microsoft SDKs\MPI\Include\"
+$env:MSMPI_LIB32 = "C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\"
+$env:MSMPI_LIB64 = "C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\"
+
+$env:PATH += ";$HOME\.cargo\bin;$env:MSMPI_BIN"
+
+$examples = `
+    Get-ChildItem "examples" `
+    | Where-Object Name -Like "*.rs" `
+    | ForEach-Object BaseName
+
+Write-Host "Running $($examples.Count) examples"
+Write-Host ""
+
+$num_ok = 0
+$num_failed = 0
+$result = "ok"
+
+foreach ($example in $examples) {
+    $failed = $false
+
+    Write-Host "Example $example on 2...8 processes"
+    $output_file = New-Item -Force "$HOME\AppData\Local\Temp\$($example)_output.txt"
+
+    foreach ($num_proc in 2..8) {
+        cmd.exe /c "cargo mpirun --no-default-features --verbose -n $num_proc --example $example 2>&1" > $output_file
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "." -NoNewline
+            Remove-Item -Force $output_file
+        } else {
+            Write-Host " failed on $num_proc processes."
+            Write-Host "output:"
+            Get-Content $output_file | Write-Output
+            Remove-Item -Force $output_file
+            $num_failed++
+            $failed = $true
+            $result = "failed"
+            break
+        }
+    }
+    if ($failed) { continue }
+    Write-Host " ok."
+    $num_ok++
+}
+
+Write-Host "example result: $result. $num_ok passed; $num_failed failed"
+exit $num_failed

--- a/examples/env_inq.rs
+++ b/examples/env_inq.rs
@@ -8,6 +8,7 @@ fn main() {
     let _universe = mpi::initialize().unwrap();
     println!("{}", mpi::environment::processor_name().unwrap());
 
+    #[cfg(not(msmpi))]
     assert!(
         version >= 3,
         "Rust MPI bindings require MPI standard 3.0 and up."

--- a/examples/immediate_barrier.rs
+++ b/examples/immediate_barrier.rs
@@ -1,9 +1,15 @@
 #![deny(warnings)]
 extern crate mpi;
 
-use mpi::traits::*;
-
+#[cfg(msmpi)]
 fn main() {
+    // There appears to be a bug with MPI_Ibarrier on MS-MPI. Its state machine is not advanced
+    // while other I/O is blocking.
+}
+
+#[cfg(not(msmpi))]
+fn main() {
+    use mpi::traits::*;
     let universe = mpi::initialize().unwrap();
     let world = universe.world();
     let size = world.size();


### PR DESCRIPTION
This also patches around a couple tests that fail for MS-MPI.

To enable AppVeyor CI for this repo, you'll need to go to https://www.appveyor.com/ and register it.