### PR TITLE
Support packing and unpack data to byte buffers

### DIFF
--- a/examples/pack.rs
+++ b/examples/pack.rs
@@ -11,7 +11,9 @@ fn main() {
     let packed = world.pack(&ints[..]);
 
     let mut new_ints = [0, 0, 0];
-    world.unpack_into(&packed, &mut new_ints[..], 0);
+    unsafe {
+        world.unpack_into(&packed, &mut new_ints[..], 0);
+    }
 
     assert_eq!([3, 2, 1], new_ints);
 }

--- a/examples/pack.rs
+++ b/examples/pack.rs
@@ -1,0 +1,17 @@
+#![deny(warnings)]
+extern crate mpi;
+
+use mpi::traits::*;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let ints = [3i32, 2, 1];
+    let packed = world.pack(&ints[..]);
+
+    let mut new_ints = [0, 0, 0];
+    world.unpack_into(&packed, &mut new_ints[..], 0);
+
+    assert_eq!([3, 2, 1], new_ints);
+}

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -36,7 +36,6 @@
 //! - **4.1.10**: Duplicating a datatype, `MPI_Type_dup()`
 //! - **4.1.11**: `MPI_Get_elements()`, `MPI_Get_elements_x()`
 //! - **4.1.13**: Decoding a datatype, `MPI_Type_get_envelope()`, `MPI_Type_get_contents()`
-//! - **4.2**: Pack and unpack, `MPI_Pack()`, `MPI_Unpack()`, `MPI_Pack_size()`
 //! - **4.3**: Canonical pack and unpack, `MPI_Pack_external()`, `MPI_Unpack_external()`,
 //! `MPI_Pack_external_size()`
 

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -436,7 +436,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         }
     }
 
-    /// Gets the implementation-defined buffer size required to pack 'incout' elements of type
+    /// Gets the implementation-defined buffer size required to pack 'incount' elements of type
     /// 'datatype'.
     ///
     /// # Standard section(s)

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -517,24 +517,22 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// # Standard Sections
     ///
     /// 4.2, see MPI_Unpack
-    fn unpack_into<Buf>(&self, inbuf: &[u8], outbuf: &mut Buf, position: Count) -> Count
+    unsafe fn unpack_into<Buf>(&self, inbuf: &[u8], outbuf: &mut Buf, position: Count) -> Count
     where
         Buf: ?Sized + BufferMut,
     {
         let outbuf_dt = outbuf.as_datatype();
 
         let mut position: Count = position;
-        unsafe {
-            ffi::MPI_Unpack(
-                inbuf.as_ptr() as *const _,
-                inbuf.count(),
-                &mut position,
-                outbuf.pointer_mut(),
-                outbuf.count(),
-                outbuf_dt.as_raw(),
-                self.as_raw(),
-            );
-        }
+        ffi::MPI_Unpack(
+            inbuf.as_ptr() as *const _,
+            inbuf.count(),
+            &mut position,
+            outbuf.pointer_mut(),
+            outbuf.count(),
+            outbuf_dt.as_raw(),
+            self.as_raw(),
+        );
         position
     }
 }


### PR DESCRIPTION
Note: I'm unsure if `unpack()` needs to be unsafe. It's unclear to me that, if the typemap of the datatype is incompatible with the buffer being provided to `MPI_Unpack`, if that results in memory unsafety. I don't *think* it does, but may need another eye on this.