### PR TITLE
MPI_Type_hvector (Removed in MPI-3) -> MPI_Type_create_hvector

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -473,7 +473,13 @@ impl UncommittedUserDatatype {
     {
         let mut newtype: MPI_Datatype = unsafe { mem::uninitialized() };
         unsafe {
-            ffi::MPI_Type_hvector(count, blocklength, stride, oldtype.as_raw(), &mut newtype);
+            ffi::MPI_Type_create_hvector(
+                count,
+                blocklength,
+                stride,
+                oldtype.as_raw(),
+                &mut newtype,
+            );
         }
         UncommittedUserDatatype(newtype)
     }


### PR DESCRIPTION
Fixes #64 