### PR TITLE
fix libffi pinning and bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpi"
-version = "0.5.4"
+version = "0.6.0"
 authors = [
     "Benedikt Steinbusch <ben@rockshrub.de>",
     "Andrew Gaspar <andrew.gaspar@outlook.com>"
@@ -23,8 +23,8 @@ user-operations = ["libffi"]
 
 [dependencies]
 conv = "0.3"
-libffi = { version = "=0.6.4", optional = true }
-mpi-sys = { path = "mpi-sys", version = "0.1" }
+libffi = { version = "0.7.0", optional = true }
+mpi-sys = { path = "mpi-sys", version = "0.2" }
 smallvec = "0.6.5"
 
 [build-dependencies]

--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpi-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     "Benedikt Steinbusch <ben@rockshrub.de>",
     "Andrew Gaspar <andrew.gaspar@outlook.com>"


### PR DESCRIPTION
Changes the `libffi` dependency to version `0.7.0` instead of pinning it at `0.6.4` which was yanked due to `bindgen` version issues (see #68 and [tov/libffi-sys-rs#21](https://github.com/tov/libffi-sys-rs/issues/21)). Fixes #69 on my system, the [latest Travis CI failures](https://travis-ci.org/bsteinb/rsmpi/builds/533988480), and closes #68.

Since the change is semver-incompatible due to `bindgen`, the `mpi` crate versions were also bumped to `0.6.0` for `mpi` and `0.2.0` for `mpi-sys`. 