### PR TITLE
Switch to rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = [ "message-passing", "parallel" ]
 categories = [ "concurrency" ]
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [workspace]
 

--- a/examples/immediate.rs
+++ b/examples/immediate.rs
@@ -58,12 +58,12 @@ fn main() {
     assert_eq!(x, msg);
 
     let future = world.any_process().immediate_receive();
-    let res = future.try();
+    let res = future.r#try();
     assert!(res.is_err());
     let mut future = res.err().unwrap();
     world.this_process().send(&x);
     loop {
-        match future.try() {
+        match future.r#try() {
             Ok((msg, _)) => {
                 assert_eq!(x, msg);
                 break;

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -22,7 +22,7 @@ use crate::ffi::MPI_Op;
 
 use crate::datatype::traits::*;
 #[cfg(feature = "user-operations")]
-use crate::datatype::DatatypeRef;
+use crate::datatype::{DatatypeRef, DynBuffer, DynBufferMut};
 use crate::raw::traits::*;
 use crate::request::{Request, Scope, StaticScope};
 use crate::topology::traits::*;

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -9,25 +9,25 @@
 //! - **5.12**: Nonblocking collective operations,
 //! `MPI_Ialltoallw()`, `MPI_Ireduce_scatter()`
 
-use std::os::raw::{c_int, c_void};
-use std::{fmt, ptr};
 #[cfg(any(msmpi, feature = "user-operations"))]
 use std::mem;
+use std::os::raw::{c_int, c_void};
+use std::{fmt, ptr};
 
 #[cfg(feature = "user-operations")]
 use libffi::high::Closure4;
 
-use ffi;
-use ffi::MPI_Op;
+use crate::ffi;
+use crate::ffi::MPI_Op;
 
-use datatype::traits::*;
+use crate::datatype::traits::*;
+use crate::raw::traits::*;
+use crate::request::{Request, Scope, StaticScope};
+use crate::topology::traits::*;
+use crate::topology::{Process, Rank};
+use crate::with_uninitialized;
 #[cfg(feature = "user-operations")]
 use datatype::{DatatypeRef, DynBuffer, DynBufferMut};
-use raw::traits::*;
-use request::{Request, Scope, StaticScope};
-use topology::traits::*;
-use topology::{Process, Rank};
-use with_uninitialized;
 
 /// Collective communication traits
 pub mod traits {
@@ -312,7 +312,10 @@ pub trait CommunicatorCollectives: Communicator {
     /// 5.12.1
     fn immediate_barrier(&self) -> Request<'static> {
         unsafe {
-            Request::from_raw(with_uninitialized(|request| ffi::MPI_Ibarrier(self.as_raw(), request)).1, StaticScope)
+            Request::from_raw(
+                with_uninitialized(|request| ffi::MPI_Ibarrier(self.as_raw(), request)).1,
+                StaticScope,
+            )
         }
     }
 
@@ -340,7 +343,7 @@ pub trait CommunicatorCollectives: Communicator {
         unsafe {
             let recvcount = recvbuf.count() / self.size();
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iallgather(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -351,8 +354,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -380,7 +384,7 @@ pub trait CommunicatorCollectives: Communicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iallgatherv(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -391,9 +395,10 @@ pub trait CommunicatorCollectives: Communicator {
                         recvbuf.as_datatype().as_raw(),
                         self.as_raw(),
                         request,
-                        )
-                ).1,
-                scope
+                    )
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -421,7 +426,7 @@ pub trait CommunicatorCollectives: Communicator {
         let c_size = self.size();
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ialltoall(
                         sendbuf.pointer(),
                         sendbuf.count() / c_size,
@@ -432,8 +437,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -456,7 +462,7 @@ pub trait CommunicatorCollectives: Communicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ialltoallv(
                         sendbuf.pointer(),
                         sendbuf.counts_ptr(),
@@ -469,8 +475,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -500,7 +507,7 @@ pub trait CommunicatorCollectives: Communicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iallreduce(
                         sendbuf.pointer(),
                         recvbuf.pointer_mut(),
@@ -510,8 +517,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -543,7 +551,7 @@ pub trait CommunicatorCollectives: Communicator {
         assert_eq!(recvbuf.count() * self.size(), sendbuf.count());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ireduce_scatter_block(
                         sendbuf.pointer(),
                         recvbuf.pointer_mut(),
@@ -553,8 +561,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -584,7 +593,7 @@ pub trait CommunicatorCollectives: Communicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iscan(
                         sendbuf.pointer(),
                         recvbuf.pointer_mut(),
@@ -594,8 +603,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -625,7 +635,7 @@ pub trait CommunicatorCollectives: Communicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iexscan(
                         sendbuf.pointer(),
                         recvbuf.pointer_mut(),
@@ -635,8 +645,9 @@ pub trait CommunicatorCollectives: Communicator {
                         self.as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1056,7 +1067,7 @@ pub trait Root: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ibcast(
                         buf.pointer_mut(),
                         buf.count(),
@@ -1065,8 +1076,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1090,7 +1102,7 @@ pub trait Root: AsCommunicator {
         assert_ne!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Igather(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -1102,8 +1114,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1134,7 +1147,7 @@ pub trait Root: AsCommunicator {
         unsafe {
             let recvcount = recvbuf.count() / self.as_communicator().size();
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Igather(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -1146,8 +1159,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1175,7 +1189,7 @@ pub trait Root: AsCommunicator {
         assert_ne!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Igatherv(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -1188,8 +1202,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1219,7 +1234,7 @@ pub trait Root: AsCommunicator {
         assert_eq!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Igatherv(
                         sendbuf.pointer(),
                         sendbuf.count(),
@@ -1232,8 +1247,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1261,7 +1277,7 @@ pub trait Root: AsCommunicator {
         assert_ne!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iscatter(
                         ptr::null(),
                         0,
@@ -1273,8 +1289,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1305,7 +1322,7 @@ pub trait Root: AsCommunicator {
         unsafe {
             let sendcount = sendbuf.count() / self.as_communicator().size();
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iscatter(
                         sendbuf.pointer(),
                         sendcount,
@@ -1317,8 +1334,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1346,7 +1364,7 @@ pub trait Root: AsCommunicator {
         assert_ne!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iscatterv(
                         ptr::null(),
                         ptr::null(),
@@ -1359,8 +1377,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1390,7 +1409,7 @@ pub trait Root: AsCommunicator {
         assert_eq!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Iscatterv(
                         sendbuf.pointer(),
                         sendbuf.counts_ptr(),
@@ -1403,8 +1422,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1435,7 +1455,7 @@ pub trait Root: AsCommunicator {
         assert_ne!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ireduce(
                         sendbuf.pointer(),
                         ptr::null_mut(),
@@ -1446,8 +1466,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1480,7 +1501,7 @@ pub trait Root: AsCommunicator {
         assert_eq!(self.as_communicator().rank(), self.root_rank());
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ireduce(
                         sendbuf.pointer(),
                         recvbuf.pointer_mut(),
@@ -1491,8 +1512,9 @@ pub trait Root: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -1679,7 +1701,10 @@ impl<'a> UserOperation<'a> {
         let op;
         anchor.ffi_closure = Some(unsafe {
             let ffi_closure = Closure4::new(&anchor.rust_closure);
-            op = with_uninitialized(|op| ffi::MPI_Op_create(Some(*ffi_closure.code_ptr()), commute as _, op)).1;
+            op = with_uninitialized(|op| {
+                ffi::MPI_Op_create(Some(*ffi_closure.code_ptr()), commute as _, op)
+            })
+            .1;
             mem::transmute(ffi_closure) // erase the lifetime
         });
         UserOperation {
@@ -1815,7 +1840,9 @@ impl UnsafeUserOperation {
         #[cfg(msmpi)]
         let function = mem::transmute(function);
 
-        UnsafeUserOperation { op: with_uninitialized(|op| ffi::MPI_Op_create(Some(function), commute as _, op)).1 }
+        UnsafeUserOperation {
+            op: with_uninitialized(|op| ffi::MPI_Op_create(Some(function), commute as _, op)).1,
+        }
     }
 }
 

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -21,13 +21,13 @@ use crate::ffi;
 use crate::ffi::MPI_Op;
 
 use crate::datatype::traits::*;
+#[cfg(feature = "user-operations")]
+use crate::datatype::DatatypeRef;
 use crate::raw::traits::*;
 use crate::request::{Request, Scope, StaticScope};
 use crate::topology::traits::*;
 use crate::topology::{Process, Rank};
 use crate::with_uninitialized;
-#[cfg(feature = "user-operations")]
-use datatype::{DatatypeRef, DynBuffer, DynBufferMut};
 
 /// Collective communication traits
 pub mod traits {

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -74,12 +74,12 @@ use conv::ConvUtil;
 
 use super::{Address, Count};
 
-use ffi;
-use ffi::MPI_Datatype;
+use crate::ffi;
+use crate::ffi::MPI_Datatype;
 
-use raw::traits::*;
+use crate::raw::traits::*;
 
-use with_uninitialized;
+use crate::with_uninitialized;
 
 /// Datatype traits
 pub mod traits {
@@ -434,9 +434,10 @@ impl UncommittedUserDatatype {
     {
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
-                   ffi::MPI_Type_contiguous(count, oldtype.as_raw(), newtype)
-                ).1
+                with_uninitialized(|newtype| {
+                    ffi::MPI_Type_contiguous(count, oldtype.as_raw(), newtype)
+                })
+                .1,
             )
         }
     }
@@ -456,9 +457,10 @@ impl UncommittedUserDatatype {
     {
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_vector(count, blocklength, stride, oldtype.as_raw(), newtype)
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -479,7 +481,7 @@ impl UncommittedUserDatatype {
     {
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_create_hvector(
                         count,
                         blocklength,
@@ -487,7 +489,8 @@ impl UncommittedUserDatatype {
                         oldtype.as_raw(),
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -511,7 +514,7 @@ impl UncommittedUserDatatype {
 
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_indexed(
                         blocklengths.count(),
                         blocklengths.as_ptr(),
@@ -519,7 +522,8 @@ impl UncommittedUserDatatype {
                         oldtype.as_raw(),
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -546,7 +550,7 @@ impl UncommittedUserDatatype {
         );
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_create_hindexed(
                         blocklengths.count(),
                         blocklengths.as_ptr(),
@@ -554,7 +558,8 @@ impl UncommittedUserDatatype {
                         oldtype.as_raw(),
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -570,7 +575,7 @@ impl UncommittedUserDatatype {
     {
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_create_indexed_block(
                         displacements.count(),
                         blocklength,
@@ -578,7 +583,8 @@ impl UncommittedUserDatatype {
                         oldtype.as_raw(),
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -599,7 +605,7 @@ impl UncommittedUserDatatype {
     {
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_create_hindexed_block(
                         displacements.count(),
                         blocklength,
@@ -607,7 +613,8 @@ impl UncommittedUserDatatype {
                         oldtype.as_raw(),
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -637,7 +644,7 @@ impl UncommittedUserDatatype {
 
         unsafe {
             UncommittedUserDatatype(
-                with_uninitialized(|newtype|
+                with_uninitialized(|newtype| {
                     ffi::MPI_Type_create_struct(
                         blocklengths.count(),
                         blocklengths.as_ptr(),
@@ -645,7 +652,8 @@ impl UncommittedUserDatatype {
                         types.as_ptr() as *const _,
                         newtype,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -732,9 +740,7 @@ pub trait UncommittedDatatype: AsRaw<Raw = MPI_Datatype> {
     fn dup(&self) -> Self::DuplicatedDatatype {
         unsafe {
             Self::DuplicatedDatatype::from_raw(
-                with_uninitialized(|newtype|
-                    ffi::MPI_Type_dup(self.as_raw(), newtype)
-                ).1
+                with_uninitialized(|newtype| ffi::MPI_Type_dup(self.as_raw(), newtype)).1,
             )
         }
     }
@@ -1403,7 +1409,5 @@ where
 /// 4.1.5
 pub fn address_of<T>(x: &T) -> Address {
     let x: *const T = x;
-    unsafe {
-        with_uninitialized(|address| ffi::MPI_Get_address(x as *const c_void, address)).1
-    }
+    unsafe { with_uninitialized(|address| ffi::MPI_Get_address(x as *const c_void, address)).1 }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -9,14 +9,14 @@
 //! - **8.3, 8.4, and 8.5**: Error handling
 use std::cmp::Ordering;
 use std::os::raw::{c_char, c_double, c_int, c_void};
-use std::string::FromUtf8Error;
 use std::ptr;
+use std::string::FromUtf8Error;
 
 use conv::ConvUtil;
 
-use ffi;
-use topology::SystemCommunicator;
-use {with_uninitialized, with_uninitialized2};
+use crate::ffi;
+use crate::topology::SystemCommunicator;
+use crate::{with_uninitialized, with_uninitialized2};
 
 /// Global context
 pub struct Universe {
@@ -154,9 +154,7 @@ impl From<c_int> for Threading {
 
 /// Whether the MPI library has been initialized
 fn is_initialized() -> bool {
-    unsafe {
-        with_uninitialized(|initialized| ffi::MPI_Initialized(initialized)).1 != 0
-    }
+    unsafe { with_uninitialized(|initialized| ffi::MPI_Initialized(initialized)).1 != 0 }
 }
 
 /// Initialize MPI.
@@ -194,15 +192,15 @@ pub fn initialize_with_threading(threading: Threading) -> Option<(Universe, Thre
     if is_initialized() {
         None
     } else {
-        let (_, provided ) = unsafe {
-            with_uninitialized(|provided|
+        let (_, provided) = unsafe {
+            with_uninitialized(|provided| {
                 ffi::MPI_Init_thread(
                     ptr::null_mut(),
                     ptr::null_mut(),
                     threading.as_raw(),
                     provided,
                 )
-            )
+            })
         };
         Some((Universe { buffer: None }, provided.into()))
     }
@@ -216,9 +214,9 @@ pub fn initialize_with_threading(threading: Threading) -> Option<(Universe, Thre
 /// See `examples/init_with_threading.rs`
 pub fn threading_support() -> Threading {
     unsafe {
-        with_uninitialized(|threading|
-            ffi::MPI_Query_thread(threading)
-        ).1.into()
+        with_uninitialized(|threading| ffi::MPI_Query_thread(threading))
+            .1
+            .into()
     }
 }
 
@@ -229,9 +227,7 @@ pub fn threading_support() -> Threading {
 /// Can be called without initializing MPI.
 pub fn version() -> (c_int, c_int) {
     let (_, version, subversion) = unsafe {
-        with_uninitialized2(|version, subversion|
-            ffi::MPI_Get_version(version, subversion)
-        )
+        with_uninitialized2(|version, subversion| ffi::MPI_Get_version(version, subversion))
     };
     (version, subversion)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,13 +121,6 @@
 use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 
-extern crate conv;
-#[cfg(feature = "user-operations")]
-extern crate libffi;
-extern crate mpi_sys;
-#[macro_use]
-extern crate smallvec;
-
 /// The raw C language MPI API
 ///
 /// Documented in the [Message Passing Interface specification][spec]
@@ -163,17 +156,19 @@ pub mod topology;
 
 /// Re-exports all traits.
 pub mod traits {
-    pub use collective::traits::*;
-    pub use datatype::traits::*;
-    pub use point_to_point::traits::*;
-    pub use raw::traits::*;
-    pub use topology::traits::*;
+    pub use crate::collective::traits::*;
+    pub use crate::datatype::traits::*;
+    pub use crate::point_to_point::traits::*;
+    pub use crate::raw::traits::*;
+    pub use crate::topology::traits::*;
 }
 
 #[doc(inline)]
-pub use environment::{initialize, initialize_with_threading, time, time_resolution, Threading};
+pub use crate::environment::{
+    initialize, initialize_with_threading, time, time_resolution, Threading,
+};
 
-use ffi::MPI_Aint;
+use crate::ffi::MPI_Aint;
 
 /// Encodes error values returned by MPI functions.
 pub type Error = c_int;
@@ -190,7 +185,7 @@ type IntArray = smallvec::SmallVec<[c_int; 8]>;
 
 unsafe fn with_uninitialized<F, U, R>(f: F) -> (R, U)
 where
-    F: FnOnce(*mut U) -> R
+    F: FnOnce(*mut U) -> R,
 {
     let mut uninitialized = MaybeUninit::uninit();
     let res = f(uninitialized.as_mut_ptr());
@@ -199,10 +194,14 @@ where
 
 unsafe fn with_uninitialized2<F, U1, U2, R>(f: F) -> (R, U1, U2)
 where
-    F: FnOnce(*mut U1, *mut U2) -> R
+    F: FnOnce(*mut U1, *mut U2) -> R,
 {
     let mut uninitialized1 = MaybeUninit::uninit();
     let mut uninitialized2 = MaybeUninit::uninit();
     let res = f(uninitialized1.as_mut_ptr(), uninitialized2.as_mut_ptr());
-    (res, uninitialized1.assume_init(), uninitialized2.assume_init())
+    (
+        res,
+        uninitialized1.assume_init(),
+        uninitialized2.assume_init(),
+    )
 }

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -12,22 +12,22 @@
 //! `MPI_Rsend_init()`, `MPI_Recv_init()`, `MPI_Start()`, `MPI_Startall()`
 
 use std::alloc::{self, Layout};
-use std::{fmt, ptr};
 use std::mem::MaybeUninit;
+use std::{fmt, ptr};
 
 use conv::ConvUtil;
 
 use super::{Count, Tag};
 
-use ffi;
-use ffi::{MPI_Message, MPI_Status};
+use crate::ffi;
+use crate::ffi::{MPI_Message, MPI_Status};
 
-use datatype::traits::*;
-use raw::traits::*;
-use request::{Request, Scope, StaticScope};
-use topology::traits::*;
-use topology::{AnyProcess, CommunicatorRelation, Process, Rank};
-use {with_uninitialized, with_uninitialized2};
+use crate::datatype::traits::*;
+use crate::raw::traits::*;
+use crate::request::{Request, Scope, StaticScope};
+use crate::topology::traits::*;
+use crate::topology::{AnyProcess, CommunicatorRelation, Process, Rank};
+use crate::{with_uninitialized, with_uninitialized2};
 
 // TODO: rein in _with_tag ugliness, use optional tags or make tag part of Source and Destination
 
@@ -66,14 +66,15 @@ pub unsafe trait Source: AsCommunicator {
     fn probe_with_tag(&self, tag: Tag) -> Status {
         unsafe {
             Status(
-                with_uninitialized(|status|
+                with_uninitialized(|status| {
                     ffi::MPI_Probe(
                         self.source_rank(),
                         tag,
                         self.as_communicator().as_raw(),
                         status,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -107,7 +108,7 @@ pub unsafe trait Source: AsCommunicator {
     /// 3.8.2
     fn matched_probe_with_tag(&self, tag: Tag) -> (Message, Status) {
         let (_, message, status) = unsafe {
-            with_uninitialized2(|message, status|
+            with_uninitialized2(|message, status| {
                 ffi::MPI_Mprobe(
                     self.source_rank(),
                     tag,
@@ -115,7 +116,7 @@ pub unsafe trait Source: AsCommunicator {
                     message,
                     status,
                 )
-            )
+            })
         };
         (Message(message), Status(status))
     }
@@ -148,7 +149,7 @@ pub unsafe trait Source: AsCommunicator {
         Msg: Equivalence,
     {
         unsafe {
-            let (_, msg, status) = with_uninitialized2(|msg, status|
+            let (_, msg, status) = with_uninitialized2(|msg, status| {
                 ffi::MPI_Recv(
                     msg as _,
                     1,
@@ -158,7 +159,7 @@ pub unsafe trait Source: AsCommunicator {
                     self.as_communicator().as_raw(),
                     status,
                 )
-            );
+            });
             let status = Status(status);
             if status.count(Msg::equivalent_datatype()) == 0 {
                 panic!("Received an empty message.");
@@ -205,7 +206,7 @@ pub unsafe trait Source: AsCommunicator {
     {
         unsafe {
             Status(
-                with_uninitialized(|status|
+                with_uninitialized(|status| {
                     ffi::MPI_Recv(
                         buf.pointer_mut(),
                         buf.count(),
@@ -215,7 +216,8 @@ pub unsafe trait Source: AsCommunicator {
                         self.as_communicator().as_raw(),
                         status,
                     )
-                ).1
+                })
+                .1,
             )
         }
     }
@@ -286,7 +288,7 @@ pub unsafe trait Source: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Irecv(
                         buf.pointer_mut(),
                         buf.count(),
@@ -296,8 +298,9 @@ pub unsafe trait Source: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -335,7 +338,7 @@ pub unsafe trait Source: AsCommunicator {
     {
         unsafe {
             let val = alloc::alloc(Layout::new::<Msg>()) as *mut Msg;
-            let (_, request) = with_uninitialized(|request|
+            let (_, request) = with_uninitialized(|request| {
                 ffi::MPI_Irecv(
                     val as _,
                     1,
@@ -345,7 +348,7 @@ pub unsafe trait Source: AsCommunicator {
                     self.as_communicator().as_raw(),
                     request,
                 )
-            );
+            });
             ReceiveFuture {
                 val,
                 req: Request::from_raw(request, StaticScope),
@@ -381,7 +384,7 @@ pub unsafe trait Source: AsCommunicator {
         unsafe {
             let mut status = MaybeUninit::uninit();
 
-            let (_, flag) = with_uninitialized(|flag|
+            let (_, flag) = with_uninitialized(|flag| {
                 ffi::MPI_Iprobe(
                     self.source_rank(),
                     tag,
@@ -389,7 +392,7 @@ pub unsafe trait Source: AsCommunicator {
                     flag,
                     status.as_mut_ptr(),
                 )
-            );
+            });
 
             if flag != 0 {
                 Some(Status(status.assume_init()))
@@ -427,7 +430,7 @@ pub unsafe trait Source: AsCommunicator {
             let mut message = MaybeUninit::uninit();
             let mut status = MaybeUninit::uninit();
 
-            let (_, flag) = with_uninitialized(|flag|
+            let (_, flag) = with_uninitialized(|flag| {
                 ffi::MPI_Improbe(
                     self.source_rank(),
                     tag,
@@ -436,7 +439,7 @@ pub unsafe trait Source: AsCommunicator {
                     message.as_mut_ptr(),
                     status.as_mut_ptr(),
                 )
-            );
+            });
 
             if flag != 0 {
                 Some((Message(message.assume_init()), Status(status.assume_init())))
@@ -680,7 +683,7 @@ pub trait Destination: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Isend(
                         buf.pointer(),
                         buf.count(),
@@ -690,8 +693,9 @@ pub trait Destination: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -733,7 +737,7 @@ pub trait Destination: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Ibsend(
                         buf.pointer(),
                         buf.count(),
@@ -743,8 +747,9 @@ pub trait Destination: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -787,7 +792,7 @@ pub trait Destination: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Issend(
                         buf.pointer(),
                         buf.count(),
@@ -797,8 +802,9 @@ pub trait Destination: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -841,7 +847,7 @@ pub trait Destination: AsCommunicator {
     {
         unsafe {
             Request::from_raw(
-                with_uninitialized(|request|
+                with_uninitialized(|request| {
                     ffi::MPI_Irsend(
                         buf.pointer(),
                         buf.count(),
@@ -851,8 +857,9 @@ pub trait Destination: AsCommunicator {
                         self.as_communicator().as_raw(),
                         request,
                     )
-                ).1,
-                scope
+                })
+                .1,
+                scope,
             )
         }
     }
@@ -953,7 +960,7 @@ impl Message {
         Msg: Equivalence,
     {
         unsafe {
-            let (_, res, status) = with_uninitialized2(|res, status|
+            let (_, res, status) = with_uninitialized2(|res, status| {
                 ffi::MPI_Mrecv(
                     res as _,
                     1,
@@ -961,7 +968,7 @@ impl Message {
                     self.as_raw_mut(),
                     status,
                 )
-            );
+            });
             let status = Status(status);
             if status.count(Msg::equivalent_datatype()) == 0 {
                 panic!("Received an empty message.");
@@ -983,7 +990,7 @@ impl Message {
     {
         let status;
         unsafe {
-            status = with_uninitialized(|status|
+            status = with_uninitialized(|status| {
                 ffi::MPI_Mrecv(
                     buf.pointer_mut(),
                     buf.count(),
@@ -991,7 +998,8 @@ impl Message {
                     self.as_raw_mut(),
                     status,
                 )
-            ).1;
+            })
+            .1;
             assert_eq!(self.as_raw(), ffi::RSMPI_MESSAGE_NULL);
         };
         Status(status)
@@ -1014,7 +1022,7 @@ impl Message {
         Sc: Scope<'a>,
     {
         unsafe {
-            let request = with_uninitialized(|request|
+            let request = with_uninitialized(|request| {
                 ffi::MPI_Imrecv(
                     buf.pointer_mut(),
                     buf.count(),
@@ -1022,7 +1030,8 @@ impl Message {
                     self.as_raw_mut(),
                     request,
                 )
-            ).1;
+            })
+            .1;
             assert_eq!(self.as_raw(), ffi::RSMPI_MESSAGE_NULL);
             Request::from_raw(request, scope)
         }
@@ -1109,7 +1118,7 @@ where
         CommunicatorRelation::Identical
     );
     unsafe {
-        let (_, res, status) = with_uninitialized2(|res, status|
+        let (_, res, status) = with_uninitialized2(|res, status| {
             ffi::MPI_Sendrecv(
                 msg.pointer(),
                 msg.count(),
@@ -1124,7 +1133,7 @@ where
                 source.as_communicator().as_raw(),
                 status,
             )
-        );
+        });
         let status = Status(status);
         (res, status)
     }
@@ -1184,7 +1193,7 @@ where
     );
     unsafe {
         Status(
-            with_uninitialized(|status|
+            with_uninitialized(|status| {
                 ffi::MPI_Sendrecv(
                     msg.pointer(),
                     msg.count(),
@@ -1199,8 +1208,9 @@ where
                     source.as_communicator().as_raw(),
                     status,
                 )
-            ).1
-       )
+            })
+            .1,
+        )
     }
 }
 
@@ -1260,7 +1270,7 @@ where
     );
     unsafe {
         Status(
-            with_uninitialized(|status|
+            with_uninitialized(|status| {
                 ffi::MPI_Sendrecv_replace(
                     buf.pointer_mut(),
                     buf.count(),
@@ -1272,7 +1282,8 @@ where
                     source.as_communicator().as_raw(),
                     status,
                 )
-            ).1
+            })
+            .1,
         )
     }
 }
@@ -1320,24 +1331,20 @@ where
         if status.count(T::equivalent_datatype()) == 0 {
             panic!("Received an empty message into a ReceiveFuture.");
         }
-        unsafe {
-            (ptr::read(self.val), status)
-        }
+        unsafe { (ptr::read(self.val), status) }
     }
 
     /// Check whether the receive operation has finished.
     ///
     /// If the operation has finished, the data received is returned. Otherwise the future itself
     /// is returned.
-    pub fn try(mut self) -> Result<(T, Status), Self> {
+    pub fn r#try(mut self) -> Result<(T, Status), Self> {
         match self.req.test() {
             Ok(status) => {
                 if status.count(T::equivalent_datatype()) == 0 {
                     panic!("Received an empty message into a ReceiveFuture.");
                 }
-                unsafe {
-                    Ok((ptr::read(self.val), status))
-                }
+                unsafe { Ok((ptr::read(self.val), status)) }
             }
             Err(request) => {
                 self.req = request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,15 +29,15 @@
 
 use std::cell::Cell;
 use std::marker::PhantomData;
-use std::mem::{ self, MaybeUninit };
+use std::mem::{self, MaybeUninit};
 use std::ptr;
 
-use ffi;
-use ffi::{MPI_Request, MPI_Status};
+use crate::ffi;
+use crate::ffi::{MPI_Request, MPI_Status};
 
-use point_to_point::Status;
-use raw::traits::*;
-use with_uninitialized;
+use crate::point_to_point::Status;
+use crate::raw::traits::*;
+use crate::with_uninitialized;
 
 /// Check if the request is `MPI_REQUEST_NULL`.
 fn is_null(request: MPI_Request) -> bool {
@@ -137,9 +137,7 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// 3.7.3
     pub fn wait(self) -> Status {
-        unsafe {
-            Status::from_raw(with_uninitialized(|status| self.wait_with(status)).1)
-        }
+        unsafe { Status::from_raw(with_uninitialized(|status| self.wait_with(status)).1) }
     }
 
     /// Wait for an operation to finish, but don’t bother retrieving the `Status` information.
@@ -170,9 +168,8 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
             let mut status = MaybeUninit::uninit();
             let mut request = self.as_raw();
 
-            let (_, flag) = with_uninitialized(|flag|
-                ffi::MPI_Test(&mut request, flag, status.as_mut_ptr())
-            );
+            let (_, flag) =
+                with_uninitialized(|flag| ffi::MPI_Test(&mut request, flag, status.as_mut_ptr()));
             if flag != 0 {
                 assert!(is_null(request)); // persistent requests are not supported
                 self.into_raw();

--- a/src/topology/cartesian.rs
+++ b/src/topology/cartesian.rs
@@ -2,9 +2,12 @@ use std::mem;
 
 use conv::ConvUtil;
 
-use super::super::{with_uninitialized, with_uninitialized2, datatype::traits::*, ffi, raw::traits::*, Count, IntArray};
 use super::{AsCommunicator, Communicator, IntoTopology, Rank, UserCommunicator};
-use ffi::MPI_Comm;
+use crate::ffi::MPI_Comm;
+use crate::{
+    datatype::traits::*, ffi, raw::traits::*, with_uninitialized, with_uninitialized2, Count,
+    IntArray,
+};
 
 /// Contains arrays describing the layout of the
 /// [`CartesianCommunicator`](struct.CartesianCommunicator.html).
@@ -77,9 +80,7 @@ impl CartesianCommunicator {
     /// # Standard section(s)
     /// 7.5.5 (MPI_Cartdim_get)
     pub fn num_dimensions(&self) -> Count {
-        unsafe {
-            with_uninitialized(|count| ffi::MPI_Cartdim_get(self.as_raw(), count)).1
-        }
+        unsafe { with_uninitialized(|count| ffi::MPI_Cartdim_get(self.as_raw(), count)).1 }
     }
 
     /// Returns the topological structure of the Cartesian communicator
@@ -104,7 +105,7 @@ impl CartesianCommunicator {
         periods: &mut [bool],
         coords: &mut [Count],
     ) {
-        let mut periods_int: IntArray = smallvec![0; periods.len()];
+        let mut periods_int: IntArray = smallvec::smallvec![0; periods.len()];
 
         ffi::MPI_Cart_get(
             self.as_raw(),
@@ -344,15 +345,16 @@ impl CartesianCommunicator {
         dimension: Count,
         displacement: Count,
     ) -> (Option<Rank>, Option<Rank>) {
-        let (_, rank_source, rank_destination) = with_uninitialized2(|rank_source, rank_destination|
-            ffi::MPI_Cart_shift(
-                self.as_raw(),
-                dimension,
-                displacement,
-                rank_source,
-                rank_destination,
-            )
-        );
+        let (_, rank_source, rank_destination) =
+            with_uninitialized2(|rank_source, rank_destination| {
+                ffi::MPI_Cart_shift(
+                    self.as_raw(),
+                    dimension,
+                    displacement,
+                    rank_source,
+                    rank_destination,
+                )
+            });
 
         let rank_source = if rank_source != ffi::RSMPI_PROC_NULL {
             Some(rank_source)
@@ -414,7 +416,12 @@ impl CartesianCommunicator {
     pub unsafe fn subgroup_unchecked(&self, retain: &[bool]) -> CartesianCommunicator {
         let retain_int: IntArray = retain.iter().map(|b| *b as _).collect();
 
-        CartesianCommunicator::from_raw_unchecked(with_uninitialized(|newcomm| ffi::MPI_Cart_sub(self.as_raw(), retain_int.as_ptr(), newcomm)).1)
+        CartesianCommunicator::from_raw_unchecked(
+            with_uninitialized(|newcomm| {
+                ffi::MPI_Cart_sub(self.as_raw(), retain_int.as_ptr(), newcomm)
+            })
+            .1,
+        )
     }
 
     /// Partitions an existing Cartesian communicator into a new Cartesian communicator in a lower

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -27,14 +27,14 @@ use std::process;
 use conv::ConvUtil;
 
 #[cfg(not(msmpi))]
-use super::Tag;
-use super::{Count, IntArray};
+use crate::Tag;
+use crate::{Count, IntArray};
 
-use super::with_uninitialized;
-use datatype::traits::*;
-use ffi;
-use ffi::{MPI_Comm, MPI_Group};
-use raw::traits::*;
+use crate::datatype::traits::*;
+use crate::ffi;
+use crate::ffi::{MPI_Comm, MPI_Group};
+use crate::raw::traits::*;
+use crate::with_uninitialized;
 
 mod cartesian;
 
@@ -163,7 +163,8 @@ impl UserCommunicator {
     /// 7.5.5
     pub fn topology(&self) -> Topology {
         unsafe {
-            let (_, topology) = with_uninitialized(|topology| ffi::MPI_Topo_test(self.as_raw(), topology));
+            let (_, topology) =
+                with_uninitialized(|topology| ffi::MPI_Topo_test(self.as_raw(), topology));
 
             if topology == ffi::RSMPI_GRAPH {
                 Topology::Graph
@@ -272,9 +273,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// 6.4.1
     fn size(&self) -> Rank {
-        unsafe {
-            with_uninitialized(|size| ffi::MPI_Comm_size(self.as_raw(), size)).1
-        }
+        unsafe { with_uninitialized(|size| ffi::MPI_Comm_size(self.as_raw(), size)).1 }
     }
 
     /// The `Rank` that identifies the calling process within this communicator
@@ -286,9 +285,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// 6.4.1
     fn rank(&self) -> Rank {
-        unsafe {
-            with_uninitialized(|rank| ffi::MPI_Comm_rank(self.as_raw(), rank)).1
-        }
+        unsafe { with_uninitialized(|rank| ffi::MPI_Comm_rank(self.as_raw(), rank)).1 }
     }
 
     /// Bundles a reference to this communicator with a specific `Rank` into a `Process`.
@@ -333,7 +330,9 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         C: Communicator,
     {
         unsafe {
-            with_uninitialized(|cmp| ffi::MPI_Comm_compare(self.as_raw(), other.as_raw(), cmp)).1.into()
+            with_uninitialized(|cmp| ffi::MPI_Comm_compare(self.as_raw(), other.as_raw(), cmp))
+                .1
+                .into()
         }
     }
 
@@ -348,7 +347,9 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// 6.4.2
     fn duplicate(&self) -> UserCommunicator {
         unsafe {
-            UserCommunicator::from_raw_unchecked(with_uninitialized(|newcomm| ffi::MPI_Comm_dup(self.as_raw(), newcomm)).1)
+            UserCommunicator::from_raw_unchecked(
+                with_uninitialized(|newcomm| ffi::MPI_Comm_dup(self.as_raw(), newcomm)).1,
+            )
         }
     }
 
@@ -379,7 +380,12 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     /// 6.4.2
     fn split_by_color_with_key(&self, color: Color, key: Key) -> Option<UserCommunicator> {
         unsafe {
-            UserCommunicator::from_raw(with_uninitialized(|newcomm| ffi::MPI_Comm_split(self.as_raw(), color.as_raw(), key, newcomm)).1)
+            UserCommunicator::from_raw(
+                with_uninitialized(|newcomm| {
+                    ffi::MPI_Comm_split(self.as_raw(), color.as_raw(), key, newcomm)
+                })
+                .1,
+            )
         }
     }
 
@@ -406,7 +412,12 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         G: Group,
     {
         unsafe {
-            UserCommunicator::from_raw(with_uninitialized(|newcomm| ffi::MPI_Comm_create(self.as_raw(), group.as_raw(), newcomm)).1)
+            UserCommunicator::from_raw(
+                with_uninitialized(|newcomm| {
+                    ffi::MPI_Comm_create(self.as_raw(), group.as_raw(), newcomm)
+                })
+                .1,
+            )
         }
     }
 
@@ -443,7 +454,12 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         G: Group,
     {
         unsafe {
-            UserCommunicator::from_raw(with_uninitialized(|newcomm| ffi::MPI_Comm_create_group(self.as_raw(), group.as_raw(), tag, newcomm)).1)
+            UserCommunicator::from_raw(
+                with_uninitialized(|newcomm| {
+                    ffi::MPI_Comm_create_group(self.as_raw(), group.as_raw(), tag, newcomm)
+                })
+                .1,
+            )
         }
     }
 
@@ -493,9 +509,9 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         unsafe {
             let mut buf = MaybeUninit::<BufType>::uninit();
 
-            let (_, _resultlen) = with_uninitialized(|resultlen|
+            let (_, _resultlen) = with_uninitialized(|resultlen| {
                 ffi::MPI_Comm_get_name(self.as_raw(), &mut (*buf.as_mut_ptr())[0], resultlen)
-            );
+            });
 
             let buf_cstr = CStr::from_ptr(buf.assume_init().as_ptr());
             buf_cstr.to_string_lossy().into_owned()
@@ -592,7 +608,10 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
         Dt: Datatype,
     {
         unsafe {
-            with_uninitialized(|size| ffi::MPI_Pack_size(incount, datatype.as_raw(), self.as_raw(), size)).1
+            with_uninitialized(|size| {
+                ffi::MPI_Pack_size(incount, datatype.as_raw(), self.as_raw(), size)
+            })
+            .1
         }
     }
 
@@ -837,7 +856,12 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         G: Group,
     {
         unsafe {
-            UserGroup(with_uninitialized(|newgroup| ffi::MPI_Group_union(self.as_raw(), other.as_raw(), newgroup)).1)
+            UserGroup(
+                with_uninitialized(|newgroup| {
+                    ffi::MPI_Group_union(self.as_raw(), other.as_raw(), newgroup)
+                })
+                .1,
+            )
         }
     }
 
@@ -854,7 +878,12 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         G: Group,
     {
         unsafe {
-            UserGroup(with_uninitialized(|newgroup| ffi::MPI_Group_intersection(self.as_raw(), other.as_raw(), newgroup)).1)
+            UserGroup(
+                with_uninitialized(|newgroup| {
+                    ffi::MPI_Group_intersection(self.as_raw(), other.as_raw(), newgroup)
+                })
+                .1,
+            )
         }
     }
 
@@ -871,7 +900,12 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         G: Group,
     {
         unsafe {
-            UserGroup(with_uninitialized(|newgroup| ffi::MPI_Group_difference(self.as_raw(), other.as_raw(), newgroup)).1)
+            UserGroup(
+                with_uninitialized(|newgroup| {
+                    ffi::MPI_Group_difference(self.as_raw(), other.as_raw(), newgroup)
+                })
+                .1,
+            )
         }
     }
 
@@ -885,7 +919,12 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// 6.3.2
     fn include(&self, ranks: &[Rank]) -> UserGroup {
         unsafe {
-            UserGroup(with_uninitialized(|newgroup| ffi::MPI_Group_incl(self.as_raw(), ranks.count(), ranks.as_ptr(), newgroup)).1)
+            UserGroup(
+                with_uninitialized(|newgroup| {
+                    ffi::MPI_Group_incl(self.as_raw(), ranks.count(), ranks.as_ptr(), newgroup)
+                })
+                .1,
+            )
         }
     }
 
@@ -899,7 +938,12 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     /// 6.3.2
     fn exclude(&self, ranks: &[Rank]) -> UserGroup {
         unsafe {
-            UserGroup(with_uninitialized(|newgroup| ffi::MPI_Group_excl(self.as_raw(), ranks.count(), ranks.as_ptr(), newgroup)).1)
+            UserGroup(
+                with_uninitialized(|newgroup| {
+                    ffi::MPI_Group_excl(self.as_raw(), ranks.count(), ranks.as_ptr(), newgroup)
+                })
+                .1,
+            )
         }
     }
 
@@ -909,9 +953,7 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
     ///
     /// 6.3.1
     fn size(&self) -> Rank {
-        unsafe {
-            with_uninitialized(|size| ffi::MPI_Group_size(self.as_raw(), size)).1
-        }
+        unsafe { with_uninitialized(|size| ffi::MPI_Group_size(self.as_raw(), size)).1 }
     }
 
     /// Rank of this process within the group.
@@ -942,7 +984,9 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         G: Group,
     {
         unsafe {
-            let (_, translated) = with_uninitialized(|translated| ffi::MPI_Group_translate_ranks(self.as_raw(), 1, &rank, other.as_raw(), translated));
+            let (_, translated) = with_uninitialized(|translated| {
+                ffi::MPI_Group_translate_ranks(self.as_raw(), 1, &rank, other.as_raw(), translated)
+            });
             if translated == ffi::RSMPI_UNDEFINED {
                 None
             } else {
@@ -978,7 +1022,11 @@ pub trait Group: AsRaw<Raw = MPI_Group> {
         G: Group,
     {
         unsafe {
-            with_uninitialized(|relation| ffi::MPI_Group_compare(self.as_raw(), other.as_raw(), relation)).1.into()
+            with_uninitialized(|relation| {
+                ffi::MPI_Group_compare(self.as_raw(), other.as_raw(), relation)
+            })
+            .1
+            .into()
         }
     }
 }


### PR DESCRIPTION
I want to add some async await features, so I upgraded to rust 2018 edition to support this. Async await changes will come in a separate PR.

I mostly just ran `cargo fix --edition` and `cargo fmt`, then changed a few "use" statements to use `crate::`.